### PR TITLE
Add XPath/XQuery execution to XML editor

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/domain/Favorite.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/Favorite.java
@@ -18,6 +18,8 @@ public class Favorite {
         XSD("XSD Schema Files", ".xsd"),
         SCHEMATRON("Schematron Files", ".sch"),
         XSLT("XSLT Files", ".xsl", ".xslt"),
+        XPATH("XPath Query Files", ".xpath"),
+        XQUERY("XQuery Files", ".xquery", ".xq"),
         OTHER("Other Files", "");
 
         private final String displayName;

--- a/src/main/java/org/fxt/freexmltoolkit/domain/FileFavorite.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/FileFavorite.java
@@ -41,30 +41,32 @@ public class FileFavorite {
         XSD("XSD Schema", "bi-file-earmark-check", "#007bff"),
         SCHEMATRON("Schematron Rules", "bi-file-earmark-ruled", "#dc3545"),
         XSLT("XSLT Stylesheet", "bi-file-earmark-arrow-right", "#fd7e14"),
+        XPATH("XPath Query", "bi-code-slash", "#6f42c1"),
+        XQUERY("XQuery Query", "bi-braces", "#20c997"),
         OTHER("Other", "bi-file-earmark", "#6c757d");
-        
+
         private final String displayName;
         private final String iconLiteral;
         private final String defaultColor;
-        
+
         FileType(String displayName, String iconLiteral, String defaultColor) {
             this.displayName = displayName;
             this.iconLiteral = iconLiteral;
             this.defaultColor = defaultColor;
         }
-        
+
         public String getDisplayName() {
             return displayName;
         }
-        
+
         public String getIconLiteral() {
             return iconLiteral;
         }
-        
+
         public String getDefaultColor() {
             return defaultColor;
         }
-        
+
         public static FileType fromExtension(String filePath) {
             if (filePath == null) return OTHER;
             String lower = filePath.toLowerCase();
@@ -72,6 +74,8 @@ public class FileFavorite {
             if (lower.endsWith(".xsd")) return XSD;
             if (lower.endsWith(".sch")) return SCHEMATRON;
             if (lower.endsWith(".xsl") || lower.endsWith(".xslt")) return XSLT;
+            if (lower.endsWith(".xpath")) return XPATH;
+            if (lower.endsWith(".xquery") || lower.endsWith(".xq")) return XQUERY;
             return OTHER;
         }
     }

--- a/src/main/resources/pages/tab_xml_ultimate.fxml
+++ b/src/main/resources/pages/tab_xml_ultimate.fxml
@@ -288,6 +288,18 @@
                                 <HBox spacing="10" alignment="CENTER_LEFT">
                                     <Label text="XPath Expression:" style="-fx-font-weight: bold;"/>
                                     <Region HBox.hgrow="ALWAYS"/>
+                                    <MenuButton fx:id="savedXPathQueriesMenu" text="Saved Queries" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-folder2" iconSize="14" iconColor="#6f42c1"/></graphic>
+                                    </MenuButton>
+                                    <Button text="Save" onAction="#saveXPathQuery" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-save" iconSize="14" iconColor="#17a2b8"/></graphic>
+                                        <tooltip><Tooltip text="Save query to file"/></tooltip>
+                                    </Button>
+                                    <Button text="Load" onAction="#loadXPathQueryFromFile" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-folder2-open" iconSize="14" iconColor="#007bff"/></graphic>
+                                        <tooltip><Tooltip text="Load query from file"/></tooltip>
+                                    </Button>
+                                    <Separator orientation="VERTICAL"/>
                                     <MenuButton text="Examples" style="-fx-font-size: 11px;">
                                         <graphic><FontIcon iconLiteral="bi-collection" iconSize="14"/></graphic>
                                         <items>
@@ -315,6 +327,18 @@
                                 <HBox spacing="10" alignment="CENTER_LEFT">
                                     <Label text="XQuery Expression:" style="-fx-font-weight: bold;"/>
                                     <Region HBox.hgrow="ALWAYS"/>
+                                    <MenuButton fx:id="savedXQueryQueriesMenu" text="Saved Queries" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-folder2" iconSize="14" iconColor="#20c997"/></graphic>
+                                    </MenuButton>
+                                    <Button text="Save" onAction="#saveXQueryQuery" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-save" iconSize="14" iconColor="#17a2b8"/></graphic>
+                                        <tooltip><Tooltip text="Save query to file"/></tooltip>
+                                    </Button>
+                                    <Button text="Load" onAction="#loadXQueryQueryFromFile" style="-fx-font-size: 11px;">
+                                        <graphic><FontIcon iconLiteral="bi-folder2-open" iconSize="14" iconColor="#007bff"/></graphic>
+                                        <tooltip><Tooltip text="Load query from file"/></tooltip>
+                                    </Button>
+                                    <Separator orientation="VERTICAL"/>
                                     <MenuButton text="Examples" style="-fx-font-size: 11px;">
                                         <graphic><FontIcon iconLiteral="bi-collection" iconSize="14"/></graphic>
                                         <items>


### PR DESCRIPTION
- Add XPATH and XQUERY file types to FileType enum in both Favorite and FileFavorite classes for proper query file categorization
- Create ~/.freexmltoolkit/queries/xpath/ and xquery/ directories for storing saved queries
- Add FavoritesService methods for query file management:
  - getSavedXPathQueries()/getSavedXQueryQueries()
  - saveXPathQuery()/saveXQueryQuery()
  - loadQuery() and deleteQuery()
  - getXPathQueriesDir()/getXQueryQueriesDir()
- Add UI elements to XPath/XQuery panel:
  - "Saved Queries" dropdown with dynamic query list
  - "Save" and "Load" buttons for each query type
  - "Add to Favorites" option in dropdown
  - "Open Queries Folder" option for easy file management
- Queries are saved as .xpath and .xquery files in user home directory
- Full favorites integration allows organizing queries with tags/folders

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class saved query support for both XPath and XQuery, including persistence, discovery, and favorites.
> 
> - Introduces query storage dirs `~/.freexmltoolkit/queries/xpath` and `~/.freexmltoolkit/queries/xquery` managed by `FavoritesService` (`getSaved*Queries`, `save*Query`, `loadQuery`, `deleteQuery`, `get*QueriesDir`)
> - Updates enums to recognize new types: `Favorite.FileType` adds `XPATH`/`XQUERY`; `FileFavorite.FileType` adds `XPATH`/`XQUERY` with icons and extension detection
> - Enhances `XmlUltimateController` with save/load APIs, favorites add, open-folder, and dynamic "Saved Queries" menus; initializes menus and loads queries into editors
> - Updates FXML to add "Saved Queries" dropdowns plus "Save"/"Load" buttons in both `XPath` and `XQuery` tabs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fec6f1edb50d79cee5904b56fc00082c2406d055. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->