### PR TITLE
Add image embedding to XSD documentation export

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/domain/PdfDocumentationConfig.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/PdfDocumentationConfig.java
@@ -428,6 +428,7 @@ public class PdfDocumentationConfig {
     private boolean includeToc = true;
     private boolean includeSchemaOverview = true;
     private boolean includeSchemaDiagram = true;
+    private boolean includeElementDiagrams = false;
     private boolean includeComplexTypes = true;
     private boolean includeSimpleTypes = true;
     private boolean includeDataDictionary = true;
@@ -478,6 +479,7 @@ public class PdfDocumentationConfig {
         this.includeToc = other.includeToc;
         this.includeSchemaOverview = other.includeSchemaOverview;
         this.includeSchemaDiagram = other.includeSchemaDiagram;
+        this.includeElementDiagrams = other.includeElementDiagrams;
         this.includeComplexTypes = other.includeComplexTypes;
         this.includeSimpleTypes = other.includeSimpleTypes;
         this.includeDataDictionary = other.includeDataDictionary;
@@ -648,6 +650,14 @@ public class PdfDocumentationConfig {
 
     public void setIncludeSchemaDiagram(boolean includeSchemaDiagram) {
         this.includeSchemaDiagram = includeSchemaDiagram;
+    }
+
+    public boolean isIncludeElementDiagrams() {
+        return includeElementDiagrams;
+    }
+
+    public void setIncludeElementDiagrams(boolean includeElementDiagrams) {
+        this.includeElementDiagrams = includeElementDiagrams;
     }
 
     public boolean isIncludeComplexTypes() {

--- a/src/main/java/org/fxt/freexmltoolkit/domain/WordDocumentationConfig.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/WordDocumentationConfig.java
@@ -108,6 +108,7 @@ public class WordDocumentationConfig {
     private boolean includeToc = true;
     private boolean includeDataDictionary = true;
     private boolean includeSchemaDiagram = true;
+    private boolean includeElementDiagrams = false;
 
     // Styling
     private HeaderStyle headerStyle = HeaderStyle.PROFESSIONAL;
@@ -133,6 +134,7 @@ public class WordDocumentationConfig {
         this.includeToc = other.includeToc;
         this.includeDataDictionary = other.includeDataDictionary;
         this.includeSchemaDiagram = other.includeSchemaDiagram;
+        this.includeElementDiagrams = other.includeElementDiagrams;
         this.headerStyle = other.headerStyle;
     }
 
@@ -184,6 +186,14 @@ public class WordDocumentationConfig {
 
     public void setIncludeSchemaDiagram(boolean includeSchemaDiagram) {
         this.includeSchemaDiagram = includeSchemaDiagram;
+    }
+
+    public boolean isIncludeElementDiagrams() {
+        return includeElementDiagrams;
+    }
+
+    public void setIncludeElementDiagrams(boolean includeElementDiagrams) {
+        this.includeElementDiagrams = includeElementDiagrams;
     }
 
     public HeaderStyle getHeaderStyle() {

--- a/src/main/resources/pages/tab_xsd.fxml
+++ b/src/main/resources/pages/tab_xsd.fxml
@@ -720,7 +720,12 @@
                             </CheckBox>
                             <CheckBox fx:id="wordIncludeSchemaDiagram" selected="true" text="Include Schema Diagram">
                                 <tooltip>
-                                    <Tooltip text="Embed the schema diagram as an image"/>
+                                    <Tooltip text="Embed the main schema diagram as an image"/>
+                                </tooltip>
+                            </CheckBox>
+                            <CheckBox fx:id="wordIncludeElementDiagrams" selected="false" text="Include Element Diagrams">
+                                <tooltip>
+                                    <Tooltip text="Embed SVG diagrams for each element in the Data Dictionary"/>
                                 </tooltip>
                             </CheckBox>
 
@@ -779,6 +784,11 @@
                                                 <CheckBox fx:id="pdfIncludeToc" text="Include Table of Contents" selected="true"/>
                                                 <CheckBox fx:id="pdfIncludeSchemaOverview" text="Include Schema Overview" selected="true"/>
                                                 <CheckBox fx:id="pdfIncludeSchemaDiagram" text="Include Schema Diagram" selected="true"/>
+                                                <CheckBox fx:id="pdfIncludeElementDiagrams" text="Include Element Diagrams" selected="false">
+                                                    <tooltip>
+                                                        <Tooltip text="Embed SVG diagrams for each element in the Data Dictionary"/>
+                                                    </tooltip>
+                                                </CheckBox>
                                                 <CheckBox fx:id="pdfIncludeComplexTypes" text="Include ComplexTypes Section" selected="true"/>
                                                 <CheckBox fx:id="pdfIncludeSimpleTypes" text="Include SimpleTypes Section" selected="true"/>
                                                 <CheckBox fx:id="pdfIncludeDataDictionary" text="Include Data Dictionary" selected="true"/>


### PR DESCRIPTION
- Add 'Include Element Diagrams' checkbox to Word and PDF options in FXML
- Extend WordDocumentationConfig and PdfDocumentationConfig with includeElementDiagrams field
- Update XsdController with captureWordConfig() and capturePdfConfig() methods
- Implement createElementDiagramsSection() in XsdDocumentationWordService
  - Generates PNG diagrams for elements at levels 0-2 with children
  - Embeds diagrams with captions in Word document
- Implement element diagrams section in XsdDocumentationPdfService
  - Generates PNG images to temp directory
  - Adds diagram entries to intermediate XML
  - Extends XSL-FO template with fo:external-graphic for image embedding
  - Includes automatic cleanup of temp images after PDF generation