### PR TITLE
fix: auto-expand column widths when grid cells are expanded

### DIFF
--- a/docs/superpowers/plans/2026-03-26-grid-column-width-expansion.md
+++ b/docs/superpowers/plans/2026-03-26-grid-column-width-expansion.md
@@ -1,0 +1,42 @@
+# Grid Column Width Expansion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a complex table cell is expanded, the column width should grow to fit the expanded content so that labels and values are fully visible.
+
+**Architecture:** Recalculate column widths after cell expand/collapse, considering the widths needed by expanded sub-rows. Increase `MAX_COLUMN_WIDTH` for expanded columns. Fix sub-row rendering to use the full column width instead of splitting it in half.
+
+**Tech Stack:** Java 25, JavaFX 24.0.1, Canvas (GraphicsContext)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/RepeatingElementsTable.java` | Modify | Recalculate column widths considering expanded cell content |
+| `src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/XmlCanvasView.java` | Modify | Fix sub-row rendering to use full column width, trigger width recalculation |
+
+---
+
+### Task 1: Recalculate column widths considering expanded content
+
+**Files:**
+- Modify: `RepeatingElementsTable.java`
+- Modify: `XmlCanvasView.java`
+
+- [ ] **Step 1: Update `calculateColumnWidths()` in RepeatingElementsTable to account for expanded cells**
+
+Add logic: for each column, if any row has that column expanded, calculate the max width needed by the sub-rows (label + value + indent + icon) and use that as the column width. Raise `MAX_COLUMN_WIDTH` to 500 for columns with expanded cells.
+
+- [ ] **Step 2: Fix sub-row rendering in XmlCanvasView `renderInlineTable()`**
+
+Change the sub-row rendering to use a fixed split point (e.g. 40% label, 60% value) of the column width instead of `colWidth / 2`, and remove the overly aggressive truncation.
+
+- [ ] **Step 3: Trigger column width recalculation after cell expand/collapse**
+
+In `handleTableClick()`, after `row.toggleColumnExpanded()`, call `table.recalculateColumnWidths()` before `recalculateVisibleRows()`.
+
+- [ ] **Step 4: Verify build and tests**
+
+- [ ] **Step 5: Commit and push**

--- a/src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/RepeatingElementsTable.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/RepeatingElementsTable.java
@@ -62,10 +62,14 @@ public class RepeatingElementsTable {
     public static final double MIN_COLUMN_WIDTH = 80;
 
     /**
-     * The maximum width of a table column in pixels.
-     * Columns will not be wider than this value unless they contain expanded cells.
+     * The maximum width of a table column in pixels for non-expanded content.
      */
     public static final double MAX_COLUMN_WIDTH = 250;
+
+    /**
+     * The maximum width of a table column in pixels when it has expanded cells.
+     */
+    public static final double MAX_COLUMN_WIDTH_EXPANDED = 500;
 
     /**
      * The padding around the grid content in pixels.
@@ -833,14 +837,29 @@ public class RepeatingElementsTable {
     private void calculateColumnWidths() {
         for (TableColumn col : columns) {
             double maxWidth = col.getDisplayName().length() * 8 + CELL_PADDING * 2;
+            boolean hasExpandedCells = false;
 
             for (TableRow row : rows) {
                 String value = row.getValue(col.getName());
                 double valueWidth = value.length() * 7 + CELL_PADDING * 2;
                 maxWidth = Math.max(maxWidth, valueWidth);
+
+                // Account for expanded cell content
+                if (row.isColumnExpanded(col.getName())) {
+                    hasExpandedCells = true;
+                    List<FlatRow> cellRows = row.getExpandedCellRows(col.getName());
+                    for (FlatRow subRow : cellRows) {
+                        double subIndent = subRow.getDepth() * 12;
+                        double labelWidth = (subRow.getLabel() != null ? subRow.getLabel().length() * 7 : 0);
+                        double valueW = (subRow.getValue() != null ? subRow.getValue().length() * 7 : 0);
+                        double subRowWidth = CELL_PADDING + subIndent + 18 + labelWidth + 20 + valueW + CELL_PADDING;
+                        maxWidth = Math.max(maxWidth, subRowWidth);
+                    }
+                }
             }
 
-            col.setWidth(Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, maxWidth)));
+            double maxAllowed = hasExpandedCells ? MAX_COLUMN_WIDTH_EXPANDED : MAX_COLUMN_WIDTH;
+            col.setWidth(Math.min(maxAllowed, Math.max(MIN_COLUMN_WIDTH, maxWidth)));
         }
     }
 

--- a/src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/XmlCanvasView.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/v2/xmleditor/view/XmlCanvasView.java
@@ -1123,12 +1123,24 @@ public class XmlCanvasView extends Pane {
                 if (row.isColumnExpanded(colName)) {
                     List<FlatRow> cellRows = row.getExpandedCellRows(colName);
                     double subRowY = rowTop + RepeatingElementsTable.ROW_HEIGHT;
+
+                    // Calculate label column width: max label width + indent + icon
+                    double maxLabelWidth = 0;
+                    for (FlatRow sr : cellRows) {
+                        double lw = sr.getDepth() * 12 + ICON_AREA_WIDTH
+                                + (sr.getLabel() != null ? sr.getLabel().length() * 7.2 : 0);
+                        maxLabelWidth = Math.max(maxLabelWidth, lw);
+                    }
+                    double labelColWidth = Math.min(maxLabelWidth + 20, colWidth * 0.5);
+                    double valueStartX = cellX + RepeatingElementsTable.CELL_PADDING + labelColWidth;
+
                     for (FlatRow subRow : cellRows) {
                         double subIndent = subRow.getDepth() * 12;
                         double subIconX = cellX + RepeatingElementsTable.CELL_PADDING + subIndent;
+                        double subCenterY = subRowY + RepeatingElementsTable.ROW_HEIGHT / 2;
 
                         // Draw row icon
-                        drawRowIcon(subRow.getType(), subIconX, subRowY + RepeatingElementsTable.ROW_HEIGHT / 2);
+                        drawRowIcon(subRow.getType(), subIconX, subCenterY);
 
                         // Draw label
                         gc.setFont(ROW_FONT);
@@ -1137,16 +1149,17 @@ public class XmlCanvasView extends Pane {
                         gc.setTextBaseline(VPos.CENTER);
                         String subLabel = subRow.getLabel();
                         if (subLabel != null) {
-                            gc.fillText(truncateText(subLabel, colWidth / 2 - RepeatingElementsTable.CELL_PADDING - subIndent - ICON_AREA_WIDTH),
-                                    subIconX + ICON_AREA_WIDTH, subRowY + RepeatingElementsTable.ROW_HEIGHT / 2);
+                            double availLabel = labelColWidth - subIndent - ICON_AREA_WIDTH;
+                            gc.fillText(truncateText(subLabel, availLabel),
+                                    subIconX + ICON_AREA_WIDTH, subCenterY);
                         }
 
                         // Draw value
                         if (subRow.getValue() != null) {
                             gc.setFill(getRowValueColor(subRow.getType()));
-                            double valueX = cellX + colWidth / 2;
-                            gc.fillText(truncateText(subRow.getValue(), colWidth / 2 - RepeatingElementsTable.CELL_PADDING),
-                                    valueX, subRowY + RepeatingElementsTable.ROW_HEIGHT / 2);
+                            double availValue = colWidth - labelColWidth - RepeatingElementsTable.CELL_PADDING * 2;
+                            gc.fillText(truncateText(subRow.getValue(), availValue),
+                                    valueStartX, subCenterY);
                         }
 
                         subRowY += RepeatingElementsTable.ROW_HEIGHT;
@@ -1217,6 +1230,7 @@ public class XmlCanvasView extends Pane {
                         double cellLeft = table.getColumnX(col.getName());
                         if (mx >= cellLeft && mx <= cellLeft + 16) {
                             row.toggleColumnExpanded(col.getName());
+                            table.recalculateColumnWidths();
                             recalculateVisibleRows();
                             updateScrollBars();
                             render();


### PR DESCRIPTION
- Recalculate column widths after cell expand/collapse, considering the widths needed by expanded sub-rows (labels + values + indent)
- Raise max column width from 250px to 500px for expanded columns
- Fix sub-row rendering to use dynamic label/value split instead of hardcoded colWidth/2 which truncated most content