### PR TITLE
fix(icons): repair ikonli wildcard imports in FXML

### DIFF
--- a/src/main/resources/pages/controls/FavoritesPanel.fxml
+++ b/src/main/resources/pages/controls/FavoritesPanel.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.effect.DropShadow?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.fxt.freexmltoolkit.controller.controls.FavoritesPanelController"
       styleClass="favorites-panel" prefWidth="350" minWidth="280"

--- a/src/main/resources/pages/documentation_tab.fxml
+++ b/src/main/resources/pages/documentation_tab.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 
 <Tab text="Documentation" styleClass="output-tab" closable="false"
      xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1"

--- a/src/main/resources/pages/flatten_tab.fxml
+++ b/src/main/resources/pages/flatten_tab.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.*?>
 <?import org.fxmisc.flowless.VirtualizedScrollPane?>
 <?import org.fxmisc.richtext.CodeArea?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 
 <Tab fx:id="flattenTab" text="Flatten Schema" styleClass="utility-tab" closable="false"
      xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1"

--- a/src/main/resources/pages/main.fxml
+++ b/src/main/resources/pages/main.fxml
@@ -24,7 +24,7 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.Font?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <AnchorPane prefHeight="800.0" prefWidth="1400.0"
             stylesheets="@../css/app-theme.css, @../css/fxt-theme.css"
             xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1"

--- a/src/main/resources/pages/popup_schema_generator.fxml
+++ b/src/main/resources/pages/popup_schema_generator.fxml
@@ -3,7 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="600.0" prefWidth="800.0" spacing="10" styleClass="popup-container"
       xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1">

--- a/src/main/resources/pages/popup_templates.fxml
+++ b/src/main/resources/pages/popup_templates.fxml
@@ -3,7 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="500.0" prefWidth="700.0" spacing="10" styleClass="popup-container"
       xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1">

--- a/src/main/resources/pages/schema_analysis_tab.fxml
+++ b/src/main/resources/pages/schema_analysis_tab.fxml
@@ -2,7 +2,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 
 <Tab fx:id="schemaAnalysisTab" text="Schema Analysis" styleClass="primary-tab" closable="false"
      xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1"

--- a/src/main/resources/pages/settings.fxml
+++ b/src/main/resources/pages/settings.fxml
@@ -20,7 +20,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <AnchorPane xmlns="http://javafx.com/javafx/11.0.14-internal"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.fxt.freexmltoolkit.controller.SettingsController"

--- a/src/main/resources/pages/tab_fop.fxml
+++ b/src/main/resources/pages/tab_fop.fxml
@@ -3,7 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.fxt.freexmltoolkit.controller.FopController"

--- a/src/main/resources/pages/tab_help.fxml
+++ b/src/main/resources/pages/tab_help.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0"
       xmlns="http://javafx.com/javafx/11.0.14-internal"

--- a/src/main/resources/pages/tab_json.fxml
+++ b/src/main/resources/pages/tab_json.fxml
@@ -3,7 +3,7 @@
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="768.0" prefWidth="1024.0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.JsonController"

--- a/src/main/resources/pages/tab_schema_generator.fxml
+++ b/src/main/resources/pages/tab_schema_generator.fxml
@@ -21,7 +21,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="768.0" prefWidth="1024.0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.SchemaGeneratorController"

--- a/src/main/resources/pages/tab_schematron.fxml
+++ b/src/main/resources/pages/tab_schematron.fxml
@@ -3,7 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="768.0" prefWidth="1024.0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.SchematronController"

--- a/src/main/resources/pages/tab_signature.fxml
+++ b/src/main/resources/pages/tab_signature.fxml
@@ -2,7 +2,7 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.fxt.freexmltoolkit.controller.SignatureController"

--- a/src/main/resources/pages/tab_unified_editor.fxml
+++ b/src/main/resources/pages/tab_unified_editor.fxml
@@ -21,7 +21,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0"
       AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.fxt.freexmltoolkit.controller.UnifiedEditorController"

--- a/src/main/resources/pages/tab_validation.fxml
+++ b/src/main/resources/pages/tab_validation.fxml
@@ -21,7 +21,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox fx:id="rootVBox"
       xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1"

--- a/src/main/resources/pages/tab_xml_ultimate.fxml
+++ b/src/main/resources/pages/tab_xml_ultimate.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="768.0" prefWidth="1024.0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.XmlUltimateController"

--- a/src/main/resources/pages/tab_xsd.fxml
+++ b/src/main/resources/pages/tab_xsd.fxml
@@ -23,7 +23,7 @@
 <?import javafx.scene.web.WebView?>
 <?import org.fxmisc.flowless.VirtualizedScrollPane?>
 <?import org.fxmisc.richtext.CodeArea?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0"
       AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.fxt.freexmltoolkit.controller.XsdController" stylesheets="@../css/xsd-tab-groups.css">

--- a/src/main/resources/pages/tab_xslt.fxml
+++ b/src/main/resources/pages/tab_xslt.fxml
@@ -22,7 +22,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
 <?import org.fxt.freexmltoolkit.controls.FileExplorer?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0"
       AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.XsltController"

--- a/src/main/resources/pages/tab_xslt_developer.fxml
+++ b/src/main/resources/pages/tab_xslt_developer.fxml
@@ -22,7 +22,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <VBox prefHeight="768.0" prefWidth="1024.0" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
       AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0" xmlns="http://javafx.com/javafx/11.0.14-internal"
       xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxt.freexmltoolkit.controller.XsltDeveloperController"

--- a/src/main/resources/pages/welcome.fxml
+++ b/src/main/resources/pages/welcome.fxml
@@ -21,7 +21,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import org.kordamp.ikonli.javafx.*?>
+<?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
 <AnchorPane fx:id="rootPane" xmlns="http://javafx.com/javafx/21"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.fxt.freexmltoolkit.controller.WelcomeController"

--- a/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconCoverageTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconCoverageTest.java
@@ -75,6 +75,35 @@ class IconifyIconCoverageTest {
         }
     }
 
+    @Test
+    void everyFxmlUsingIconifyIconImportsIt() throws IOException {
+        String importLine = "import org.fxt.freexmltoolkit.controls.icons.IconifyIcon";
+        Map<String, String> offenders = new TreeMap<>();
+        try (Stream<Path> files = Files.walk(MAIN)) {
+            files.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".fxml"))
+                    .forEach(p -> {
+                        try {
+                            String c = Files.readString(p);
+                            if (c.contains("<IconifyIcon") && !c.contains(importLine)) {
+                                offenders.put(p.toString(),
+                                        "uses <IconifyIcon> but is missing the <?import ...IconifyIcon?>");
+                            }
+                            // Guard against leftover Ikonli imports (incl. wildcards).
+                            if (c.contains("org.kordamp.ikonli")) {
+                                offenders.put(p.toString() + " (ikonli)", "still references org.kordamp.ikonli");
+                            }
+                        } catch (IOException ignored) {
+                        }
+                    });
+        }
+        if (!offenders.isEmpty()) {
+            StringBuilder sb = new StringBuilder("FXML import problems (").append(offenders.size()).append("):\n");
+            offenders.forEach((f, why) -> sb.append("  ").append(f).append(" — ").append(why).append('\n'));
+            fail(sb.toString());
+        }
+    }
+
     /** @return map of icon literal -> first file where it was seen */
     private Map<String, String> collectLiterals() throws IOException {
         Map<String, String> result = new TreeMap<>();

--- a/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconRenderTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconRenderTest.java
@@ -20,6 +20,7 @@ package org.fxt.freexmltoolkit.controls.icons;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
@@ -112,6 +113,37 @@ class IconifyIconRenderTest {
         double w16 = onFx("bi-save", 16).getLayoutBounds().getWidth();
         double w32 = onFx("bi-save", 32).getLayoutBounds().getWidth();
         assertTrue(w32 > w16 * 1.5, "32px icon should be markedly larger than 16px (" + w16 + " vs " + w32 + ")");
+    }
+
+    @Test
+    @DisplayName("IconifyIcon is instantiable from FXML")
+    void instantiableFromFxml() throws Exception {
+        String fxml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <?import org.fxt.freexmltoolkit.controls.icons.IconifyIcon?>
+                <IconifyIcon xmlns="http://javafx.com/javafx"
+                             iconLiteral="bi-save" iconSize="20" iconColor="#17a2b8"/>
+                """;
+        AtomicReference<Object> ref = new AtomicReference<>();
+        AtomicReference<Throwable> err = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                var loader = new javafx.fxml.FXMLLoader();
+                ref.set(loader.load(new java.io.ByteArrayInputStream(
+                        fxml.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+            } catch (Throwable t) {
+                err.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "FX task timed out");
+        assertNull(err.get(), () -> "FXML load failed: " + err.get());
+        assertTrue(ref.get() instanceof IconifyIcon, "root should be an IconifyIcon");
+        IconifyIcon icon = (IconifyIcon) ref.get();
+        assertEquals("bi-save", icon.getIconLiteral());
+        assertEquals(20.0, icon.getIconSize());
     }
 
     @Test


### PR DESCRIPTION
## Problem

After the Iconify migration (#27), the app crashed on startup:

```
javafx.fxml.LoadException: IconifyIcon is not a valid type. .../pages/main.fxml:39
```

The migration script rewrote the **explicit** `org.kordamp.ikonli.javafx.FontIcon` import, but 21 FXML files imported `FontIcon` via a **wildcard** (`<?import org.kordamp.ikonli.javafx.*?>`). Their `<FontIcon>` tags were renamed to `<IconifyIcon>` without a matching import, so FXML couldn't resolve the type. Because FXML is only resolved at load time (not compile time) and no test loaded these FXMLs, the build stayed green.

## Fix

- Replace the ikonli wildcard import with the explicit `IconifyIcon` import in all affected FXML files.
- **Close the test gap:**
  - `IconifyIconRenderTest` now loads `IconifyIcon` via `FXMLLoader` (this test would have caught the bug).
  - `IconifyIconCoverageTest` now asserts every FXML containing `<IconifyIcon>` imports it, and that no FXML still references `org.kordamp.ikonli`.

## Verification

`./gradlew build` green (Spotless + compile + full suite incl. the new FXML-load test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)