### PR TITLE
fix(icons): support Ikonli-style 'literal:size' suffix

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/controls/icons/IconifyIcon.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/icons/IconifyIcon.java
@@ -138,6 +138,8 @@ public class IconifyIcon extends Region {
 
     private void rebuild() {
         content.getChildren().clear();
+        // Honour Ikonli-style "literal:size[:color]" suffixes for backwards compatibility.
+        applyInlineModifiers(getIconLiteral());
         List<IconifyIconService.IconPath> paths =
                 IconifyIconService.getInstance().resolve(getIconLiteral());
 
@@ -153,6 +155,32 @@ public class IconifyIcon extends Region {
         }
         applyColor();
         applySize();
+    }
+
+    /**
+     * Applies an Ikonli-style {@code literal:size[:color]} suffix, if present, to this icon's
+     * {@code iconSize} / {@code iconColor}. The suffix is otherwise ignored by the renderer
+     * (the service resolves the bare icon name).
+     */
+    private void applyInlineModifiers(String literal) {
+        if (literal == null) {
+            return;
+        }
+        String[] parts = literal.split(":");
+        if (parts.length >= 2) {
+            try {
+                setIconSize(Double.parseDouble(parts[1].trim()));
+            } catch (NumberFormatException ignored) {
+                // Not a numeric size; leave iconSize unchanged.
+            }
+        }
+        if (parts.length >= 3 && !parts[2].isBlank()) {
+            try {
+                setIconColor(Color.web(parts[2].trim()));
+            } catch (IllegalArgumentException ignored) {
+                // Not a valid colour; leave iconColor unchanged.
+            }
+        }
     }
 
     private Node buildPlaceholder() {

--- a/src/main/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconService.java
@@ -121,6 +121,12 @@ public final class IconifyIconService {
         }
         String prefix = literal.substring(0, dash);
         String name = literal.substring(dash + 1);
+        // Tolerate Ikonli-style "name:size[:color]" suffixes (e.g. "bi-gear:16"); the size/color
+        // part is applied by IconifyIcon, here we only need the bare icon name.
+        int colon = name.indexOf(':');
+        if (colon >= 0) {
+            name = name.substring(0, colon);
+        }
 
         IconSet set = sets.computeIfAbsent(prefix, IconifyIconService::loadSet);
         if (set == null) {

--- a/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconRenderTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/controls/icons/IconifyIconRenderTest.java
@@ -147,6 +147,22 @@ class IconifyIconRenderTest {
     }
 
     @Test
+    @DisplayName("Ikonli-style 'literal:size' suffix resolves and applies the size")
+    void inlineSizeSuffix() throws Exception {
+        AtomicReference<IconifyIcon> ref = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            // Constructor only: no explicit setIconSize, so the suffix should drive the size.
+            ref.set(new IconifyIcon("bi-code-slash:24"));
+            latch.countDown();
+        });
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "FX task timed out");
+        IconifyIcon icon = ref.get();
+        assertTrue(svgPathCount(icon) >= 1, "bi-code-slash:24 should resolve the base icon");
+        assertEquals(24.0, icon.getIconSize(), "the :24 suffix should set iconSize");
+    }
+
+    @Test
     @DisplayName("Unknown literal renders a placeholder and does not throw")
     void unknownLiteralFallsBack() throws Exception {
         IconifyIcon icon = onFx("bi-does-not-exist-xyz", 16);


### PR DESCRIPTION
## Problem

Runtime warnings + placeholder icons for literals using Ikonli's inline-modifier syntax:

```
Icon 'code-slash:16' not found in Iconify set 'bi'
Icon 'columns-gap:16' not found in Iconify set 'bi'
```

`IconifyIcon("bi-code-slash:16")` uses Ikonli's `name:size[:color]` form. The new resolver treated `code-slash:16` as the icon name, so it failed to resolve and rendered the fallback placeholder.

## Fix

- `IconifyIconService` strips a trailing `:size[:color]` suffix before icon lookup.
- `IconifyIcon` parses the suffix and applies the size (and optional colour), preserving the old `FontIcon` semantics.
- Regression test: `bi-code-slash:24` resolves the base icon and applies size 24.

## Verification

`./gradlew test --tests "*IconifyIcon*"` green (incl. the new suffix test and the FXML-load test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)