### PR TITLE
security: harden XML/XSLT/FOP processing, auto-update integrity, SSL & XSS

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Features
 
-> **Last Updated:** May 2026 | **Version:** 1.10.0
+> **Last Updated:** June 2026 | **Version:** 1.10.0
 
 This page describes the security measures built into FreeXmlToolkit to protect you from XML-based attacks.
 
@@ -17,6 +17,7 @@ When working with XML files, there are several potential security risks - especi
 | [SSRF Protection](#ssrf-server-side-request-forgery-protection) | Documents accessing your internal network |
 | [Path Traversal Protection](#path-traversal-protection) | Files accessing restricted system directories |
 | [XPath Injection Protection](#xpath-injection-protection) | Malicious input breaking XPath queries |
+| [Update Integrity Verification](#automatic-update-integrity) | Tampered or man-in-the-middle update downloads |
 
 These protections work automatically in the background - you do not need to configure them for normal use.
 
@@ -262,6 +263,45 @@ This prevents the user input from breaking out of the string literal and modifyi
 
 ---
 
+## Automatic Update Integrity
+
+### What Is This?
+
+When FreeXmlToolkit downloads an application update, it verifies that the downloaded file is exactly the one published by the official release - and was not tampered with in transit (for example by a man-in-the-middle on an untrusted network) or swapped on the download server.
+
+### How It Works
+
+1. The update package (a ZIP) is downloaded from the official GitHub release over HTTPS.
+2. Before the package is extracted or launched, its **SHA-256 checksum** is computed locally.
+3. That checksum is compared against the SHA-256 **digest that GitHub publishes for the release asset**, fetched over a separate TLS-protected connection to the GitHub API.
+4. **If the checksums do not match, the update is aborted** and the downloaded file is deleted. Nothing is installed.
+
+This means that even if an attacker could intercept or replace the download, the mismatch would be detected and the update refused.
+
+> **Note:** The certificate-validation bypass setting (`ssl.trustAllCerts`, used only for connection testing) never applies to update downloads. Update traffic always validates TLS certificates.
+
+### When No Published Checksum Is Available
+
+GitHub only began publishing per-asset digests in 2025, so some older releases may not have one. By default, when no trustworthy digest is available, the update **proceeds with a warning** written to the application log (preserving compatibility with those releases).
+
+If you prefer a stricter policy, you can require a verified checksum for **every** update - any update without one will be refused:
+
+```
+update.requireChecksum=true
+```
+
+| Behavior | `update.requireChecksum=false` (default) | `update.requireChecksum=true` |
+|----------|------------------------------------------|-------------------------------|
+| Checksum present and matches | Update proceeds | Update proceeds |
+| Checksum present but **mismatches** | **Update aborted** | **Update aborted** |
+| No checksum published | Update proceeds (logged warning) | **Update aborted** |
+
+### What This Means for You
+
+**For normal use you do not need to change anything** - integrity verification runs automatically. Set `update.requireChecksum=true` only if your environment requires that no update is ever installed without a cryptographically verified checksum.
+
+---
+
 ## How to Configure Security Settings
 
 ### Finding Security Settings
@@ -283,6 +323,7 @@ For advanced users, security settings are stored in the application properties f
 | Property | Values | Description |
 |----------|--------|-------------|
 | `security.xslt.allow.extensions` | `true` / `false` | Enable/disable Java extensions in XSLT |
+| `update.requireChecksum` | `true` / `false` | Require a verified SHA-256 checksum for every update; refuse updates that have no published checksum (default `false`) |
 
 ### Best Practices
 
@@ -320,6 +361,18 @@ For advanced users, security settings are stored in the application properties f
 
 **Solution:** Check your schema imports and includes for unusual paths. Use absolute paths or properly relative paths that stay within your project directory.
 
+### "Integrity verification failed" during an update
+
+**Cause:** The downloaded update did not match the checksum published for the release. This usually indicates a corrupted download or interference on the network, and the update was refused.
+
+**Solution:** Retry the update on a trusted network connection. If it keeps failing, download the latest release manually from the official GitHub releases page.
+
+### An update was refused with "no published checksum"
+
+**Cause:** You set `update.requireChecksum=true`, and the target release does not have a published checksum.
+
+**Solution:** Either update manually from the official release page, or set `update.requireChecksum=false` to allow updates that have no published checksum (the default behavior).
+
 ---
 
 ## Technical Reference
@@ -340,6 +393,13 @@ All XML parsers use these security features:
 
 - `Feature.ALLOW_EXTERNAL_FUNCTIONS` = false (by default)
 - Configurable via application settings
+
+### Update Integrity Verification
+
+- Downloaded update artifact is hashed with `SHA-256` and compared against the digest GitHub publishes for the release asset (retrieved over TLS from the Releases API).
+- Mismatch aborts the update and deletes the artifact before any extraction or launch.
+- The `ssl.trustAllCerts` connection-test bypass is never applied to update downloads, which always perform standard certificate validation.
+- `update.requireChecksum=true` additionally refuses any update that has no published digest.
 
 ### URL Validation
 

--- a/src/main/java/org/fxt/freexmltoolkit/controls/v2/editor/managers/ValidationManagerV2.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/v2/editor/managers/ValidationManagerV2.java
@@ -28,6 +28,7 @@ import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyleSpansBuilder;
 import org.fxt.freexmltoolkit.controls.v2.editor.core.EditorContext;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -314,7 +315,8 @@ public class ValidationManagerV2 {
         }
 
         logger.debug("Creating new Schema for: {}", filePath);
-        SchemaFactory schemaFactory = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        SchemaFactory schemaFactory = SecureXmlFactory.createSecureSchemaFactory(
+                javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
         cachedSchema = schemaFactory.newSchema(schemaFile);
         cachedSchemaFilePath = filePath;
         cachedSchemaLastModified = lastModified;

--- a/src/main/java/org/fxt/freexmltoolkit/domain/XsdDocumentationData.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/XsdDocumentationData.java
@@ -178,8 +178,28 @@ public class XsdDocumentationData {
         if (namespaces == null || namespaces.isEmpty()) {
             return "";
         }
+        // The result is rendered as raw HTML (th:utext) because of the <br /> separators, so the
+        // schema-derived prefixes and URIs MUST be HTML-escaped to prevent stored XSS in the
+        // generated documentation.
         return namespaces.entrySet().stream()
-                .map(entry -> entry.getKey() + "='" + entry.getValue() + "'")
+                .map(entry -> escapeHtml(entry.getKey()) + "='" + escapeHtml(entry.getValue()) + "'")
                 .collect(Collectors.joining("<br />"));
+    }
+
+    /**
+     * Escapes HTML special characters to prevent injection when the value is rendered as raw HTML.
+     *
+     * @param text the text to escape (may be {@code null})
+     * @return the escaped text, or an empty string if {@code text} is {@code null}
+     */
+    private static String escapeHtml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#x27;");
     }
 }

--- a/src/main/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceImpl.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceImpl.java
@@ -176,6 +176,23 @@ public class AutoUpdateServiceImpl implements AutoUpdateService {
                     return UpdateResult.failure("Update cancelled by user");
                 }
 
+                // Stage 2b: Integrity verification
+                // SECURITY: verify the downloaded artifact against the SHA-256 digest that GitHub
+                // publishes for the release asset (fetched over TLS from the Releases API). This
+                // prevents a tampered/MITM'd download from being extracted and executed.
+                reportProgress(progressCallback, UpdateStage.DOWNLOADING, Files.size(zipFile),
+                        Files.size(zipFile), "Verifying download integrity...");
+                try {
+                    verifyDownloadIntegrity(zipFile, downloadUrl, updateInfo, debugLog);
+                } catch (SecurityException se) {
+                    writeDebugLog(debugLog, "SECURITY: integrity verification FAILED: " + se.getMessage());
+                    logger.error("Update integrity verification failed: {}", se.getMessage());
+                    Files.deleteIfExists(zipFile);
+                    reportProgress(progressCallback, UpdateStage.FAILED, 0, -1,
+                            "Integrity check failed: " + se.getMessage());
+                    return UpdateResult.failure("Integrity verification failed: " + se.getMessage());
+                }
+
                 // Stage 3: Extracting
                 reportProgress(progressCallback, UpdateStage.EXTRACTING, 0, -1,
                         "Extracting update...");
@@ -770,6 +787,160 @@ public class AutoUpdateServiceImpl implements AutoUpdateService {
                 "https://github.com/%s/%s/releases/download/v%s/FreeXmlToolkit-%s-app-image-%s.zip",
                 GITHUB_OWNER, GITHUB_REPO, version, platform, version
         );
+    }
+
+    /**
+     * Verifies the integrity of a downloaded release artifact against the SHA-256 digest that
+     * GitHub publishes for the asset.
+     *
+     * <p>The expected digest is read from the GitHub Releases API (over TLS) for the release tag
+     * matching the update version, and compared against the locally computed SHA-256 of the
+     * downloaded file. A mismatch throws {@link SecurityException}, aborting the update.
+     *
+     * <p>GitHub only began populating the per-asset {@code digest} field in 2025, so it may be
+     * absent for older releases. When no trustworthy digest is available the behaviour is governed
+     * by the {@code update.requireChecksum} property (default {@code false}): when disabled, the
+     * update proceeds with a prominent warning (preserving compatibility with pre-digest releases);
+     * when enabled, the update is aborted.
+     *
+     * @param zipFile     the downloaded artifact
+     * @param downloadUrl the URL the artifact was downloaded from (its last path segment is the asset name)
+     * @param updateInfo  the update info (provides the release version/tag)
+     * @param debugLog    the debug log file
+     * @throws SecurityException if the digest does not match, or no digest is available and strict mode is on
+     * @throws IOException       if the file cannot be read
+     */
+    private void verifyDownloadIntegrity(Path zipFile, String downloadUrl, UpdateInfo updateInfo,
+                                         Path debugLog) throws IOException {
+        String assetName = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
+        String expectedSha256 = fetchExpectedSha256(updateInfo, assetName, debugLog);
+
+        if (expectedSha256 == null || expectedSha256.isBlank()) {
+            boolean strict = isChecksumRequired();
+            String msg = "No published SHA-256 digest available for asset '" + assetName + "'";
+            if (strict) {
+                throw new SecurityException(msg + " and update.requireChecksum is enabled");
+            }
+            logger.warn("SECURITY: {} - proceeding without integrity verification "
+                    + "(set update.requireChecksum=true to enforce)", msg);
+            writeDebugLog(debugLog, "WARNING: " + msg + " - integrity NOT verified");
+            return;
+        }
+
+        String actualSha256 = computeSha256(zipFile);
+        writeDebugLog(debugLog, "Expected SHA-256: " + expectedSha256);
+        writeDebugLog(debugLog, "Actual   SHA-256: " + actualSha256);
+
+        if (!expectedSha256.equalsIgnoreCase(actualSha256)) {
+            throw new SecurityException("SHA-256 mismatch for " + assetName
+                    + " (expected " + expectedSha256 + ", got " + actualSha256 + ")");
+        }
+        logger.info("Update integrity verified: SHA-256 matches published digest for {}", assetName);
+        writeDebugLog(debugLog, "Integrity verification PASSED for " + assetName);
+    }
+
+    /**
+     * Fetches the expected SHA-256 digest for the named release asset from the GitHub Releases API.
+     *
+     * @param updateInfo the update info providing the release version/tag
+     * @param assetName  the asset file name to look up
+     * @param debugLog   the debug log file
+     * @return the lower-case hex SHA-256 digest, or {@code null} if unavailable
+     */
+    private String fetchExpectedSha256(UpdateInfo updateInfo, String assetName, Path debugLog) {
+        try {
+            String version = updateInfo.latestVersion();
+            if (version != null && version.startsWith("v")) {
+                version = version.substring(1);
+            }
+            String apiUrl = String.format(
+                    "https://api.github.com/repos/%s/%s/releases/tags/v%s",
+                    GITHUB_OWNER, GITHUB_REPO, version);
+
+            ConnectionService connectionService = ServiceRegistry.get(ConnectionService.class);
+            var result = connectionService.executeHttpRequest(URI.create(apiUrl));
+            if (result == null || result.httpStatus() == null || result.httpStatus() != 200
+                    || result.resultBody() == null || result.resultBody().isBlank()) {
+                writeDebugLog(debugLog, "Could not fetch release metadata for digest lookup (status: "
+                        + (result != null ? result.httpStatus() : "null") + ")");
+                return null;
+            }
+
+            com.google.gson.JsonObject release =
+                    com.google.gson.JsonParser.parseString(result.resultBody()).getAsJsonObject();
+            if (!release.has("assets") || !release.get("assets").isJsonArray()) {
+                return null;
+            }
+            for (var element : release.getAsJsonArray("assets")) {
+                com.google.gson.JsonObject asset = element.getAsJsonObject();
+                String name = asset.has("name") && !asset.get("name").isJsonNull()
+                        ? asset.get("name").getAsString() : null;
+                if (!assetName.equals(name)) {
+                    continue;
+                }
+                if (asset.has("digest") && !asset.get("digest").isJsonNull()) {
+                    String digest = asset.get("digest").getAsString();
+                    // GitHub formats the digest as "sha256:<hex>"
+                    if (digest.toLowerCase().startsWith("sha256:")) {
+                        return digest.substring("sha256:".length()).trim().toLowerCase();
+                    }
+                    writeDebugLog(debugLog, "Asset digest present but not SHA-256: " + digest);
+                }
+                return null; // matched asset but no usable digest
+            }
+            writeDebugLog(debugLog, "Asset '" + assetName + "' not found in release metadata");
+            return null;
+        } catch (Exception e) {
+            logger.warn("Failed to fetch expected SHA-256 digest: {}", e.getMessage());
+            writeDebugLog(debugLog, "ERROR fetching digest: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Computes the SHA-256 digest of a file as a lower-case hex string.
+     *
+     * @param file the file to hash
+     * @return the lower-case hex SHA-256 digest
+     * @throws IOException if the file cannot be read or SHA-256 is unavailable
+     */
+    private String computeSha256(Path file) throws IOException {
+        try {
+            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(file))) {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    digest.update(buffer, 0, read);
+                }
+            }
+            byte[] hash = digest.digest();
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    /**
+     * Returns whether a published checksum is mandatory for updates to proceed.
+     * Controlled by the {@code update.requireChecksum} property (default {@code false}).
+     *
+     * @return true if updates must be aborted when no published digest is available
+     */
+    private boolean isChecksumRequired() {
+        try {
+            PropertiesService propertiesService = ServiceRegistry.get(PropertiesService.class);
+            return Boolean.parseBoolean(
+                    propertiesService.loadProperties().getProperty("update.requireChecksum", "false"));
+        } catch (Exception e) {
+            logger.debug("Could not read update.requireChecksum, defaulting to false: {}", e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceImpl.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceImpl.java
@@ -537,8 +537,15 @@ public class AutoUpdateServiceImpl implements AutoUpdateService {
                 pb = new ProcessBuilder(tempHelper.toString(), configFile.toString());
                 writeDebugLog(debugLog, "Launching Rust helper directly (no elevation)");
             } else {
-                String command = "Start-Process -FilePath '" + tempHelper +
-                    "' -ArgumentList '" + configFile + "' -Verb RunAs";
+                // SECURITY/ROBUSTNESS: build the PowerShell command with properly escaped
+                // single-quoted literals. PowerShell single-quoted strings are literal (backticks
+                // and $ are NOT interpreted), so the only required escaping is doubling embedded
+                // single quotes. Without this, a path containing an apostrophe (e.g. a Windows
+                // user "O'Brien") would break out of the quoting.
+                String psFilePath = escapePowerShellSingleQuoted(tempHelper.toString());
+                String psArgument = escapePowerShellSingleQuoted(configFile.toString());
+                String command = "Start-Process -FilePath '" + psFilePath +
+                    "' -ArgumentList '" + psArgument + "' -Verb RunAs";
                 pb = new ProcessBuilder("powershell.exe", "-NoProfile", "-Command", command);
                 writeDebugLog(debugLog, "Launching Rust helper via PowerShell elevation: " + command);
             }
@@ -941,6 +948,20 @@ public class AutoUpdateServiceImpl implements AutoUpdateService {
             logger.debug("Could not read update.requireChecksum, defaulting to false: {}", e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Escapes a value for safe inclusion inside a PowerShell single-quoted string literal.
+     *
+     * <p>PowerShell single-quoted strings are literal: backticks, {@code $} and other metacharacters
+     * are not interpreted. The only character requiring escaping is the single quote itself, which
+     * is escaped by doubling it.
+     *
+     * @param value the raw value (e.g. a file path)
+     * @return the value safe to embed between single quotes in a PowerShell command
+     */
+    static String escapePowerShellSingleQuoted(String value) {
+        return value == null ? "" : value.replace("'", "''");
     }
 
     /**

--- a/src/main/java/org/fxt/freexmltoolkit/service/ConnectionServiceImpl.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/ConnectionServiceImpl.java
@@ -115,15 +115,15 @@ public class ConnectionServiceImpl implements ConnectionService {
                     testProperties.getProperty("http.proxy.host", "not set"),
                     System.getProperty("socksProxyHost", "not set"));
 
-            // Configure SSL bypass if enabled
+            // Read the SSL-bypass opt-in. SECURITY: the bypass is applied ONLY to this specific
+            // connection (see applySslBypassToConnection below), never to the JVM-global
+            // HttpsURLConnection defaults. Poisoning the global defaults would silently disable
+            // certificate validation for every other HTTPS connection in the process - including
+            // auto-update downloads - which must always validate certificates.
             boolean trustAllCerts = Boolean.parseBoolean(testProperties.getProperty("ssl.trustAllCerts", "false"));
             if (trustAllCerts) {
-                try {
-                    configureTrustAllSSL();
-                    logger.warn("!!! SECURITY WARNING !!! SSL certificate validation is disabled.");
-                } catch (Exception sslEx) {
-                    logger.error("Failed to configure SSL bypass, proceeding with default SSL settings: {}", sslEx.getMessage());
-                }
+                logger.warn("!!! SECURITY WARNING !!! SSL certificate validation is disabled for this "
+                        + "connection test only ({}).", uri);
             }
 
             // Configure proxy authentication
@@ -260,38 +260,12 @@ public class ConnectionServiceImpl implements ConnectionService {
     }
 
     /**
-     * Configures SSL to trust all certificates if enabled (global settings)
-     */
-    private void configureTrustAllSSL() throws NoSuchAlgorithmException, KeyManagementException {
-        // Create trust-all manager
-        TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() {
-                        return new X509Certificate[0];
-                    }
-
-                    @Override
-                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                        // Trust all
-                    }
-
-                    @Override
-                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                        // Trust all
-                    }
-                }
-        };
-        
-        // Install trust-all SSL context
-        SSLContext sc = SSLContext.getInstance("TLS");
-        sc.init(null, trustAllCerts, new java.security.SecureRandom());
-        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
-    }
-
-    /**
-     * Applies SSL bypass settings to a specific HTTPS connection
+     * Applies SSL bypass settings to a specific HTTPS connection.
+     *
+     * <p><b>Security:</b> the trust-all behaviour is intentionally scoped to the single supplied
+     * connection. The JVM-global {@code HttpsURLConnection} defaults are never modified, so
+     * disabling certificate validation here cannot leak into unrelated HTTPS connections (e.g.
+     * auto-update downloads), which must always validate certificates.
      */
     private void applySslBypassToConnection(HttpsURLConnection httpsConnection) throws NoSuchAlgorithmException, KeyManagementException {
         // Create trust-all manager for this specific connection

--- a/src/main/java/org/fxt/freexmltoolkit/service/FOPService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/FOPService.java
@@ -34,12 +34,19 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 
+import java.io.IOException;
+import java.net.URI;
+
 import org.apache.fop.apps.FOUserAgent;
 import org.apache.fop.apps.Fop;
 import org.apache.fop.apps.FopFactory;
+import org.apache.fop.apps.FopFactoryBuilder;
 import org.apache.fop.apps.MimeConstants;
+import org.apache.fop.apps.io.ResourceResolverFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.xmlgraphics.io.Resource;
+import org.apache.xmlgraphics.io.ResourceResolver;
 import org.fxt.freexmltoolkit.di.ServiceRegistry;
 import org.fxt.freexmltoolkit.domain.PDFSettings;
 
@@ -85,7 +92,7 @@ public class FOPService {
             logger.debug("PDF Output: {}", pdfOutput);
             logger.debug("Transforming...");
 
-            final FopFactory fopFactory = FopFactory.newInstance(new File(".").toURI());
+            final FopFactory fopFactory = createSecureFopFactory(new File(".").toURI());
             FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
             if (!pdfSettings.producer().isEmpty()) {
                 foUserAgent.setProducer(pdfSettings.producer());
@@ -141,6 +148,58 @@ public class FOPService {
             throw new FOPServiceException("Unexpected error during PDF generation: " + e.getMessage(), e);
         }
         return pdfOutput;
+    }
+
+    /**
+     * Creates a {@link FopFactory} whose resource resolver blocks references to network protocols
+     * (http/https/ftp).
+     *
+     * <p>This prevents a malicious FO document (or embedded SVG) from using
+     * {@code <fo:external-graphic src="http://...">} or {@code xlink:href} to perform SSRF / reach
+     * internal endpoints, or to exfiltrate data by forcing the renderer to fetch attacker-controlled
+     * URLs. Local resources (e.g. logos referenced by relative/file paths) continue to resolve via
+     * FOP's default resolver. SVG is rendered by FOP's static Batik bridge, which does not execute
+     * ECMAScript, and its external references are subject to the same resolver.
+     *
+     * @param baseUri the base URI used to resolve relative resource references
+     * @return a hardened FopFactory
+     */
+    private FopFactory createSecureFopFactory(URI baseUri) {
+        final ResourceResolver defaultResolver = ResourceResolverFactory.createDefaultResourceResolver();
+        ResourceResolver restrictedResolver = new ResourceResolver() {
+            @Override
+            public Resource getResource(URI uri) throws IOException {
+                if (isRemoteUri(uri)) {
+                    logger.warn("SECURITY: blocked remote resource reference in FO/SVG: {}", uri);
+                    throw new IOException("Blocked remote resource reference: " + uri);
+                }
+                return defaultResolver.getResource(uri);
+            }
+
+            @Override
+            public OutputStream getOutputStream(URI uri) throws IOException {
+                if (isRemoteUri(uri)) {
+                    logger.warn("SECURITY: blocked remote output URI in FO processing: {}", uri);
+                    throw new IOException("Blocked remote output reference: " + uri);
+                }
+                return defaultResolver.getOutputStream(uri);
+            }
+        };
+        return new FopFactoryBuilder(baseUri, restrictedResolver).build();
+    }
+
+    /**
+     * Determines whether a URI uses a network protocol that must be blocked during FO processing.
+     *
+     * @param uri the URI to test (may be {@code null})
+     * @return true for http/https/ftp
+     */
+    private static boolean isRemoteUri(URI uri) {
+        if (uri == null || uri.getScheme() == null) {
+            return false;
+        }
+        String scheme = uri.getScheme().toLowerCase();
+        return scheme.equals("http") || scheme.equals("https") || scheme.equals("ftp");
     }
 
     /**

--- a/src/main/java/org/fxt/freexmltoolkit/service/SaxonXmlValidationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/SaxonXmlValidationService.java
@@ -39,6 +39,7 @@ import org.fxt.freexmltoolkit.service.xsd.SchemaResolver;
 import org.fxt.freexmltoolkit.service.xsd.XsdParseOptions;
 import org.fxt.freexmltoolkit.service.xsd.XsdParsingService;
 import org.fxt.freexmltoolkit.service.xsd.XsdParsingServiceImpl;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -68,7 +69,12 @@ public class SaxonXmlValidationService implements XmlValidationService {
         this.schemaResolver = new SchemaResolver(XsdParseOptions.defaults());
         this.resourceResolver = (SchemaResolver.ValidationResourceResolver) schemaResolver.createLSResourceResolver(null);
 
-        this.factory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
+        // SECURITY: harden against XXE/SSRF. This service intentionally supports remote
+        // (http/https) schema resolution, so network protocols stay enabled while external
+        // DTD access is fully blocked and secure processing is on.
+        this.factory = SecureXmlFactory.createSecureSchemaFactory(
+                SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema"),
+                SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
         this.factory.setResourceResolver(resourceResolver);
 
         // Initialize the unified XsdParsingService for schema parsing

--- a/src/main/java/org/fxt/freexmltoolkit/service/XercesXmlValidationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XercesXmlValidationService.java
@@ -39,6 +39,7 @@ import org.fxt.freexmltoolkit.service.xsd.SchemaResolver;
 import org.fxt.freexmltoolkit.service.xsd.XsdParseOptions;
 import org.fxt.freexmltoolkit.service.xsd.XsdParsingService;
 import org.fxt.freexmltoolkit.service.xsd.XsdParsingServiceImpl;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -90,7 +91,12 @@ public class XercesXmlValidationService implements XmlValidationService {
         }
         
         // Create schema factory for XSD 1.0
-        this.schemaFactory10 = new org.apache.xerces.jaxp.validation.XMLSchemaFactory();
+        // SECURITY: harden against XXE/SSRF; this service intentionally supports remote
+        // (http/https) schema resolution, so network protocols stay enabled while external
+        // DTD access is fully blocked and secure processing is on.
+        this.schemaFactory10 = SecureXmlFactory.createSecureSchemaFactory(
+                new org.apache.xerces.jaxp.validation.XMLSchemaFactory(),
+                SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
 
         // Create schema factory for XSD 1.1
         // For XSD 1.1 support with assertions, we need to use the special Xerces XSD 1.1 implementation
@@ -139,7 +145,9 @@ public class XercesXmlValidationService implements XmlValidationService {
             // Fallback to XSD 1.0 factory
             tempFactory11 = this.schemaFactory10;
         }
-        this.schemaFactory11 = tempFactory11;
+        // SECURITY: apply the same XXE/SSRF hardening to the XSD 1.1 factory.
+        this.schemaFactory11 = SecureXmlFactory.createSecureSchemaFactory(
+                tempFactory11, SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
 
         // Configure Xerces features for better validation
         try {

--- a/src/main/java/org/fxt/freexmltoolkit/service/XmlServiceImpl.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XmlServiceImpl.java
@@ -117,7 +117,9 @@ public class XmlServiceImpl implements XmlService {
     StringWriter sw;
     Xslt30Transformer transformer;
     UrlValidator urlValidator = new UrlValidator();
-    SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    SchemaFactory factory = SecureXmlFactory.createSecureSchemaFactory(
+            SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI),
+            SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
     Transformer transform;
     XsltExecutable stylesheet;
     private File cachedXsltFile = null; // Added for caching compiled stylesheet
@@ -353,7 +355,9 @@ public class XmlServiceImpl implements XmlService {
             // STEP 2: Try to create a Schema object (optional, for XSD 1.0 validation)
             // This may fail for XSD 1.1 features (assert, alternative, etc.), but that's okay
             try {
-                SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                SchemaFactory schemaFactory = SecureXmlFactory.createSecureSchemaFactory(
+                        SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI),
+                        SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
                 this.schema = schemaFactory.newSchema(xsdFile);
                 logger.debug("Successfully created Schema object from XSD file");
             } catch (SAXException e) {

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
@@ -84,6 +84,7 @@ import org.fxt.freexmltoolkit.domain.XsdExtendedElement.RestrictionInfo;
 import org.fxt.freexmltoolkit.service.TaskProgressListener.ProgressUpdate;
 import org.fxt.freexmltoolkit.service.TaskProgressListener.ProgressUpdate.Status;
 import org.fxt.freexmltoolkit.util.PathValidator;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.jspecify.annotations.NonNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -2116,19 +2117,25 @@ public class XsdDocumentationService {
             SchemaFactory factory;
             if (requiresXsd11) {
                 // Use Xerces XSD 1.1 factory
-                factory = new org.apache.xerces.jaxp.validation.XMLSchema11Factory();
+                factory = SecureXmlFactory.createSecureSchemaFactory(
+                        new org.apache.xerces.jaxp.validation.XMLSchema11Factory());
                 logger.debug("Using XSD 1.1 schema factory for validation");
             } else {
-                factory = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                factory = SecureXmlFactory.createSecureSchemaFactory(
+                        javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
                 logger.debug("Using XSD 1.0 schema factory for validation");
             }
 
             // Set up resource resolver for imports/includes
             File schemaFile = new File(xsdFilePath);
             File schemaDir = schemaFile.getParentFile();
+            // SECURITY: block remote (http/https/ftp) schema references to prevent SSRF; this guard
+            // throws on a remote reference and is a no-op (returns null) for local references.
+            final org.w3c.dom.ls.LSResourceResolver remoteGuard = SecureXmlFactory.createLocalOnlySchemaResolver();
             factory.setResourceResolver(new org.w3c.dom.ls.LSResourceResolver() {
                 @Override
                 public org.w3c.dom.ls.LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+                    remoteGuard.resolveResource(type, namespaceURI, publicId, systemId, baseURI);
                     if (systemId != null && schemaDir != null) {
                         // SECURITY: Validate systemId before resolving
                         int traversalCount = PathValidator.countParentTraversals(systemId);

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdValidationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdValidationService.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fxt.freexmltoolkit.service.xsd.SchemaResolver;
 import org.fxt.freexmltoolkit.service.xsd.XsdParseOptions;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -437,7 +438,9 @@ public class XsdValidationService {
      */
     private Schema loadSchema(String xsdPath) {
         try {
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            SchemaFactory schemaFactory = SecureXmlFactory.createSecureSchemaFactory(
+                    SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI),
+                    SecureXmlFactory.LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS);
 
             // Configure unified schema resolver to handle relative schema references (xs:import, xs:include)
             SchemaResolver schemaResolver = new SchemaResolver(XsdParseOptions.defaults());

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsltTransformationEngine.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsltTransformationEngine.java
@@ -166,6 +166,99 @@ public class XsltTransformationEngine {
                 logger.warn("Could not disable XSLT extensions: {}", e.getMessage());
             }
         }
+
+        // Restrict resource access regardless of the extension setting: a malicious stylesheet
+        // must not be able to reach internal/remote URLs via doc()/document()/unparsed-text()
+        // (SSRF and remote data exfiltration). Local file resolution is preserved so that
+        // legitimate transforms referencing sibling data files keep working.
+        configureResourceAccess(config);
+    }
+
+    /**
+     * Installs resolvers that block network access from doc()/document() and unparsed-text().
+     *
+     * <p>References over http/https/ftp are rejected; local (file / relative) references fall
+     * through to Saxon's default resolution. This blocks SSRF and remote exfiltration without
+     * preventing legitimate local data access.
+     *
+     * @param config the Saxon configuration to harden
+     */
+    private void configureResourceAccess(Configuration config) {
+        try {
+            // doc() / document() (and other resource lookups) go through the ResourceResolver in
+            // Saxon 12. Capture the existing (default) resolver, then install a wrapper that blocks
+            // remote references and delegates everything local to the default.
+            final net.sf.saxon.lib.ResourceResolver defaultResolver = config.getResourceResolver();
+            config.setResourceResolver(request -> {
+                if (request != null && isRemoteScheme(schemeOfRequest(request))) {
+                    throw new net.sf.saxon.trans.XPathException(
+                            "Blocked remote resource reference (doc()/document()): " + request.uri);
+                }
+                // Local / relative reference: delegate to the default resolver (null = Saxon default).
+                return defaultResolver != null ? defaultResolver.resolve(request) : null;
+            });
+
+            // unparsed-text() / unparsed-text-lines(): block remote, delegate local to Saxon's
+            // standard resolver so encoding handling is preserved.
+            final net.sf.saxon.lib.UnparsedTextURIResolver standardUnparsedText =
+                    new net.sf.saxon.lib.StandardUnparsedTextResolver();
+            config.setUnparsedTextURIResolver((absoluteURI, encoding, cfg) -> {
+                if (absoluteURI != null && isRemoteScheme(absoluteURI.getScheme())) {
+                    throw new net.sf.saxon.trans.XPathException(
+                            "Blocked remote resource reference in unparsed-text(): " + absoluteURI);
+                }
+                return standardUnparsedText.resolve(absoluteURI, encoding, cfg);
+            });
+
+            logger.info("SECURITY: XSLT/XQuery network resource access (doc(), unparsed-text()) is blocked");
+        } catch (Exception e) {
+            logger.warn("Could not install restrictive resource resolvers: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Determines whether a URI scheme denotes a network protocol that should be blocked.
+     *
+     * @param scheme the URI scheme (may be {@code null})
+     * @return true for http/https/ftp
+     */
+    private static boolean isRemoteScheme(String scheme) {
+        if (scheme == null) {
+            return false;
+        }
+        String s = scheme.toLowerCase();
+        return s.equals("http") || s.equals("https") || s.equals("ftp");
+    }
+
+    /**
+     * Extracts the effective URI scheme of a Saxon {@link net.sf.saxon.lib.ResourceRequest},
+     * resolving a relative reference against its base URI when necessary.
+     *
+     * @param request the resource request
+     * @return the lower-case scheme, or {@code null} if it cannot be determined (treated as local)
+     */
+    private static String schemeOfRequest(net.sf.saxon.lib.ResourceRequest request) {
+        try {
+            if (request.uri != null && !request.uri.isBlank()) {
+                java.net.URI u = java.net.URI.create(request.uri.trim());
+                if (u.getScheme() != null) {
+                    return u.getScheme().toLowerCase();
+                }
+            }
+            if (request.relativeUri != null && request.baseUri != null
+                    && !request.baseUri.isBlank()) {
+                java.net.URI resolved = java.net.URI.create(request.baseUri.trim())
+                        .resolve(request.relativeUri.trim());
+                return resolved.getScheme() != null ? resolved.getScheme().toLowerCase() : null;
+            }
+            if (request.baseUri != null && !request.baseUri.isBlank()) {
+                return java.net.URI.create(request.baseUri.trim()).getScheme();
+            }
+        } catch (IllegalArgumentException e) {
+            logger.debug("Could not parse resource request URI (uri={}, base={}): {}",
+                    request.uri, request.baseUri, e.getMessage());
+        }
+        return null;
     }
 
     public static synchronized XsltTransformationEngine getInstance() {

--- a/src/main/java/org/fxt/freexmltoolkit/service/xsd/XsdParsingServiceImpl.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/xsd/XsdParsingServiceImpl.java
@@ -20,6 +20,7 @@ import org.fxt.freexmltoolkit.controls.v2.model.XsdNodeFactory;
 import org.fxt.freexmltoolkit.controls.v2.model.XsdSchema;
 import org.fxt.freexmltoolkit.di.ServiceRegistry;
 import org.fxt.freexmltoolkit.service.ConnectionService;
+import org.fxt.freexmltoolkit.util.SecureXmlFactory;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -291,7 +292,7 @@ public class XsdParsingServiceImpl implements XsdParsingService {
                 case XSD_1_1 -> XSD_1_1_NS;
             };
 
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(schemaLanguage);
+            SchemaFactory schemaFactory = SecureXmlFactory.createSecureSchemaFactory(schemaLanguage);
 
             // If we have a source file, use it directly
             if (parsedSchema.getSourceFile().isPresent()) {

--- a/src/main/java/org/fxt/freexmltoolkit/util/SecureXmlFactory.java
+++ b/src/main/java/org/fxt/freexmltoolkit/util/SecureXmlFactory.java
@@ -9,9 +9,13 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+
+import java.net.URI;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.w3c.dom.ls.LSResourceResolver;
 
 /**
  * Factory for creating secure XML processing components.
@@ -226,6 +230,159 @@ public final class SecureXmlFactory {
         }
 
         return factory;
+    }
+
+    /**
+     * Protocols allowed by default for external schema references (xs:import / xs:include /
+     * xs:redefine). Local files and classpath jar resources are permitted so that legitimate
+     * multi-file schemas keep working, while network protocols (http, https, ftp) are blocked
+     * to prevent SSRF and remote-file disclosure when validating an untrusted schema.
+     */
+    public static final String DEFAULT_ALLOWED_SCHEMA_PROTOCOLS = "file,jar:file";
+
+    /**
+     * Protocol set for services that <b>intentionally</b> support resolving schemas from remote
+     * locations (e.g. the XSD validation services with HTTP/HTTPS schema caching). Adds network
+     * protocols on top of {@link #DEFAULT_ALLOWED_SCHEMA_PROTOCOLS}. Prefer
+     * {@link #DEFAULT_ALLOWED_SCHEMA_PROTOCOLS} unless remote schema resolution is a required feature.
+     */
+    public static final String LOCAL_AND_REMOTE_SCHEMA_PROTOCOLS = "file,jar:file,http,https";
+
+    /**
+     * Creates a secure {@link SchemaFactory} for the given schema language with XXE / SSRF
+     * protection enabled.
+     *
+     * <p>The returned factory has:
+     * <ul>
+     *   <li>{@code FEATURE_SECURE_PROCESSING} enabled (entity-expansion limits, etc.)</li>
+     *   <li>External DTD access fully blocked ({@code ACCESS_EXTERNAL_DTD = ""})</li>
+     *   <li>External schema access restricted to {@value #DEFAULT_ALLOWED_SCHEMA_PROTOCOLS},
+     *       which permits local {@code xs:import}/{@code xs:include} while blocking network
+     *       protocols (http/https/ftp) to prevent SSRF.</li>
+     * </ul>
+     *
+     * <p>Callers that install a custom {@code LSResourceResolver} for relative imports remain
+     * fully compatible: the resolver still intercepts references first; the access restriction
+     * only governs what the default resolver is allowed to fetch.
+     *
+     * @param schemaLanguage the schema language URI, e.g.
+     *                        {@link XMLConstants#W3C_XML_SCHEMA_NS_URI}
+     * @return a secure SchemaFactory instance
+     */
+    public static SchemaFactory createSecureSchemaFactory(String schemaLanguage) {
+        return createSecureSchemaFactory(SchemaFactory.newInstance(schemaLanguage), DEFAULT_ALLOWED_SCHEMA_PROTOCOLS);
+    }
+
+    /**
+     * Applies secure XXE / SSRF settings to an existing {@link SchemaFactory}, restricting
+     * external schema references to {@value #DEFAULT_ALLOWED_SCHEMA_PROTOCOLS}.
+     *
+     * <p>Use this overload when the factory must be obtained from a specific implementation
+     * (for example the Xerces XSD 1.1 {@code XMLSchema11Factory}) rather than via
+     * {@link SchemaFactory#newInstance(String)}.
+     *
+     * @param factory the factory to harden
+     * @return the same factory instance, hardened
+     */
+    public static SchemaFactory createSecureSchemaFactory(SchemaFactory factory) {
+        return createSecureSchemaFactory(factory, DEFAULT_ALLOWED_SCHEMA_PROTOCOLS);
+    }
+
+    /**
+     * Applies secure XXE / SSRF settings to an existing {@link SchemaFactory}.
+     *
+     * <p>Always enables {@code FEATURE_SECURE_PROCESSING} and fully blocks external DTD access
+     * (DTDs in schemas are essentially never legitimate and are a pure attack vector). The set
+     * of protocols permitted for external schema references ({@code xs:import}/{@code xs:include}/
+     * {@code xs:redefine}) is caller-controlled via {@code allowedSchemaProtocols}.
+     *
+     * @param factory                the factory to harden
+     * @param allowedSchemaProtocols comma-separated protocol list for {@code ACCESS_EXTERNAL_SCHEMA}
+     *                               (e.g. {@value #DEFAULT_ALLOWED_SCHEMA_PROTOCOLS} for local-only,
+     *                               or {@code "file,jar:file,http,https"} for services that
+     *                               intentionally support remote schemas). Use {@code ""} to block
+     *                               all external schema access.
+     * @return the same factory instance, hardened
+     */
+    public static SchemaFactory createSecureSchemaFactory(SchemaFactory factory, String allowedSchemaProtocols) {
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (Exception e) {
+            logger.warn("Could not enable secure processing on SchemaFactory: {}", e.getMessage());
+        }
+        try {
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, allowedSchemaProtocols);
+            logger.trace("SchemaFactory configured with XXE/SSRF protection (schema protocols: {})", allowedSchemaProtocols);
+        } catch (Exception e) {
+            // Some SchemaFactory implementations may not support these properties
+            logger.debug("SchemaFactory does not support external access restrictions: {}", e.getMessage());
+        }
+
+        // The bundled (exist-db) Xerces fork does not reliably enforce ACCESS_EXTERNAL_SCHEMA, so
+        // when remote protocols are not explicitly allowed we additionally install a resolver that
+        // actively blocks network references. Callers that need remote schema resolution pass a
+        // protocol list containing "http"/"https" and manage their own resolver.
+        if (!allowedSchemaProtocols.toLowerCase().contains("http")) {
+            factory.setResourceResolver(createLocalOnlySchemaResolver());
+        }
+        return factory;
+    }
+
+    /**
+     * Creates an {@link LSResourceResolver} that blocks schema references over network protocols
+     * (http/https/ftp) while delegating local (file / classpath) resolution to the processor's
+     * default handling (by returning {@code null}).
+     *
+     * <p>This is the effective SSRF control for schema resolution, independent of whether the
+     * underlying parser honours the JAXP {@code ACCESS_EXTERNAL_SCHEMA} property.
+     *
+     * @return a resolver that throws {@link SecurityException} on remote references
+     */
+    public static LSResourceResolver createLocalOnlySchemaResolver() {
+        return (type, namespaceURI, publicId, systemId, baseURI) -> {
+            String scheme = resolveScheme(systemId, baseURI);
+            if (scheme != null && (scheme.equals("http") || scheme.equals("https") || scheme.equals("ftp"))) {
+                throw new SecurityException(
+                        "Blocked remote schema reference (" + scheme + "): systemId=" + systemId
+                                + ", base=" + baseURI);
+            }
+            // Local / relative references: let the processor resolve them as usual.
+            return null;
+        };
+    }
+
+    /**
+     * Determines the URI scheme of a (possibly relative) schema reference, resolving it against the
+     * supplied base URI when necessary.
+     *
+     * @param systemId the referenced system identifier (may be relative or {@code null})
+     * @param baseURI  the base URI the reference is resolved against (may be {@code null})
+     * @return the lower-case scheme (e.g. {@code "http"}, {@code "file"}), or {@code null} if it
+     *         cannot be determined (treated as local)
+     */
+    private static String resolveScheme(String systemId, String baseURI) {
+        try {
+            if (systemId != null && !systemId.isBlank()) {
+                URI sys = URI.create(systemId.trim());
+                if (sys.getScheme() != null) {
+                    return sys.getScheme().toLowerCase();
+                }
+                // Relative systemId: resolve against the base URI to discover the effective scheme.
+                if (baseURI != null && !baseURI.isBlank()) {
+                    URI resolved = URI.create(baseURI.trim()).resolve(sys);
+                    return resolved.getScheme() != null ? resolved.getScheme().toLowerCase() : null;
+                }
+            } else if (baseURI != null && !baseURI.isBlank()) {
+                URI base = URI.create(baseURI.trim());
+                return base.getScheme() != null ? base.getScheme().toLowerCase() : null;
+            }
+        } catch (IllegalArgumentException e) {
+            // Malformed URI - treat as local/unknown; the processor will reject it if invalid.
+            logger.debug("Could not parse schema reference scheme (systemId={}, base={}): {}",
+                    systemId, baseURI, e.getMessage());
+        }
+        return null;
     }
 
     /**

--- a/src/main/resources/xsdDocumentation/details/templateDetail.html
+++ b/src/main/resources/xsdDocumentation/details/templateDetail.html
@@ -353,7 +353,9 @@
             <section th:if="${appInfos != null and not #lists.isEmpty(appInfos)}">
                 <h2 id="additional-information" class="text-lg font-semibold text-slate-800 mb-3">Additional Information</h2>
                 <div class="space-y-2">
-                    <div th:each="appInfo: ${appInfos}" th:utext="${appInfo}"
+                    <!-- th:text (escaped): appInfo is plain text content extracted from xs:appinfo
+                         (getTextContent()) and must not be rendered as raw HTML (stored XSS). -->
+                    <div th:each="appInfo: ${appInfos}" th:text="${appInfo}"
                          class="p-3 bg-slate-100 rounded-md text-sm text-slate-700 font-mono">
                     </div>
                 </div>

--- a/src/test/java/org/fxt/freexmltoolkit/domain/XsdDocumentationDataTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/domain/XsdDocumentationDataTest.java
@@ -218,6 +218,25 @@ class XsdDocumentationDataTest {
             assertTrue(result.contains("xs='http://www.w3.org/2001/XMLSchema'"));
             assertTrue(result.contains("tns='http://example.com/schema'"));
         }
+
+        @Test
+        @DisplayName("Escapes HTML in namespace prefix and URI (stored XSS prevention)")
+        void escapesHtmlInNamespaceValues() {
+            // The result is rendered with th:utext (raw HTML) because of the <br /> separators,
+            // so attacker-controlled prefixes/URIs from the schema must be HTML-escaped.
+            Map<String, String> namespaces = new LinkedHashMap<>();
+            namespaces.put("evil", "http://x/\"><img src=x onerror=alert(1)>");
+            docData.setNamespaces(namespaces);
+
+            String result = docData.getNameSpacesAsString();
+
+            assertFalse(result.contains("<img"),
+                    "Raw injected markup must not appear in the output: " + result);
+            assertTrue(result.contains("&lt;img"), "Angle brackets must be escaped: " + result);
+            // The intentional <br /> separators are still allowed (it is the only markup we emit).
+            assertTrue(result.contains("&quot;") || !result.contains("\""),
+                    "Double quotes in the URI must be escaped: " + result);
+        }
     }
 
     @Nested

--- a/src/test/java/org/fxt/freexmltoolkit/security/SecureXmlFactoryTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/security/SecureXmlFactoryTest.java
@@ -271,4 +271,97 @@ class SecureXmlFactoryTest {
         var factory = SecureXmlFactory.createSecureTransformerFactory();
         assertNotNull(factory, "TransformerFactory should be created");
     }
+
+    // =========================================================================
+    // SchemaFactory Tests (XXE / SSRF hardening)
+    // =========================================================================
+
+    private static final String VALID_SCHEMA = """
+            <?xml version="1.0"?>
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:element name="root" type="xs:string"/>
+            </xs:schema>
+            """;
+
+    @Test
+    @DisplayName("SecureSchemaFactory compiles a valid self-contained schema")
+    void secureSchemaFactory_compilesValidSchema() throws Exception {
+        var factory = SecureXmlFactory.createSecureSchemaFactory(
+                javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        var schema = factory.newSchema(new javax.xml.transform.stream.StreamSource(
+                new StringReader(VALID_SCHEMA)));
+        assertNotNull(schema, "A valid self-contained schema should compile");
+    }
+
+    @Test
+    @DisplayName("SecureSchemaFactory (local-only) blocks an http xs:include (SSRF protection)")
+    void secureSchemaFactory_blocksRemoteInclude() {
+        // Local-only default must reject schema references over network protocols, preventing
+        // a malicious schema from triggering SSRF / internal-resource access. An xs:include is
+        // a mandatory reference, so a blocked network fetch surfaces as a fatal error (proving
+        // the processor never reached out over the network).
+        String remoteIncludeSchema = """
+                <?xml version="1.0"?>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                    <xs:include schemaLocation="http://169.254.169.254/evil.xsd"/>
+                    <xs:element name="root" type="xs:string"/>
+                </xs:schema>
+                """;
+
+        var factory = SecureXmlFactory.createSecureSchemaFactory(
+                javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+        Exception ex = assertThrows(Exception.class, () ->
+                        factory.newSchema(new javax.xml.transform.stream.StreamSource(
+                                new StringReader(remoteIncludeSchema))),
+                "An http xs:include must be blocked");
+        // The local-only resolver throws SecurityException; depending on the parser it may surface
+        // directly or wrapped. Verify the block reason appears somewhere in the exception chain.
+        String chain = throwableChainText(ex);
+        assertTrue(chain.toLowerCase().contains("blocked remote schema")
+                        || chain.toLowerCase().contains("access"),
+                "Failure should be due to the remote-schema block, was: " + chain);
+    }
+
+    /** Concatenates the messages of an exception and all its causes for assertion purposes. */
+    private static String throwableChainText(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable c = t; c != null && c != c.getCause(); c = c.getCause()) {
+            if (c.getMessage() != null) {
+                sb.append(c.getMessage()).append(" | ");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Test
+    @DisplayName("SecureSchemaFactory (local-only) still allows a local xs:import")
+    void secureSchemaFactory_allowsLocalImport() throws Exception {
+        // Legitimate multi-file schemas using local relative imports must keep working.
+        Path typesXsd = tempDir.resolve("types.xsd");
+        Files.writeString(typesXsd, """
+                <?xml version="1.0"?>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           targetNamespace="http://example.com/types">
+                    <xs:simpleType name="MyString">
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:schema>
+                """);
+
+        Path mainXsd = tempDir.resolve("main.xsd");
+        Files.writeString(mainXsd, """
+                <?xml version="1.0"?>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                           xmlns:t="http://example.com/types">
+                    <xs:import namespace="http://example.com/types" schemaLocation="types.xsd"/>
+                    <xs:element name="root" type="t:MyString"/>
+                </xs:schema>
+                """);
+
+        var factory = SecureXmlFactory.createSecureSchemaFactory(
+                javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        var schema = factory.newSchema(mainXsd.toFile());
+        assertNotNull(schema, "A schema with a local relative import should still compile");
+    }
 }

--- a/src/test/java/org/fxt/freexmltoolkit/security/XsltSecurityTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/security/XsltSecurityTest.java
@@ -187,4 +187,75 @@ class XsltSecurityTest {
                     "Quick transform should also block reflexive extensions");
         }
     }
+
+    @Test
+    @DisplayName("Blocks remote doc() (SSRF) without a network call")
+    void blocksRemoteDoc() {
+        // doc() pointed at a non-routable address must be rejected by the resolver immediately,
+        // not attempted over the network (which would hang until a timeout).
+        String xslt = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                    <xsl:template match="/">
+                        <result><xsl:copy-of select="doc('http://169.254.169.254/evil.xml')"/></result>
+                    </xsl:template>
+                </xsl:stylesheet>
+                """;
+
+        long start = System.currentTimeMillis();
+        XsltTransformationResult result = transformationEngine.quickTransform(SIMPLE_XML, xslt);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertFalse(result.isSuccess(), "Remote doc() must cause the transformation to fail");
+        assertTrue(elapsed < 10000,
+                "Remote doc() must be blocked immediately, not attempted over the network (took "
+                        + elapsed + " ms)");
+    }
+
+    @Test
+    @DisplayName("Blocks remote unparsed-text() (SSRF) without a network call")
+    void blocksRemoteUnparsedText() {
+        String xslt = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                    <xsl:template match="/">
+                        <result><xsl:value-of select="unparsed-text('http://169.254.169.254/evil.txt')"/></result>
+                    </xsl:template>
+                </xsl:stylesheet>
+                """;
+
+        long start = System.currentTimeMillis();
+        XsltTransformationResult result = transformationEngine.quickTransform(SIMPLE_XML, xslt);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertFalse(result.isSuccess(), "Remote unparsed-text() must cause the transformation to fail");
+        assertTrue(elapsed < 10000,
+                "Remote unparsed-text() must be blocked immediately (took " + elapsed + " ms)");
+    }
+
+    @Test
+    @DisplayName("Still allows local doc() of a sibling file")
+    void allowsLocalDoc() throws Exception {
+        // Legitimate transforms that read a local data file via doc() must keep working.
+        Path dataFile = tempDir.resolve("data.xml");
+        java.nio.file.Files.writeString(dataFile, "<data><value>LocalDocValue</value></data>");
+        String dataUri = dataFile.toUri().toString();
+
+        String xslt = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                    <xsl:template match="/">
+                        <result><xsl:value-of select="doc('%s')/data/value"/></result>
+                    </xsl:template>
+                </xsl:stylesheet>
+                """.formatted(dataUri);
+
+        XsltTransformationResult result = transformationEngine.quickTransform(SIMPLE_XML, xslt);
+
+        assertTrue(result.isSuccess(),
+                "Local doc() should still work. Error: " + result.getErrorMessage());
+        assertTrue(result.getOutputContent() != null
+                        && result.getOutputContent().contains("LocalDocValue"),
+                "Output should contain the local document value");
+    }
 }

--- a/src/test/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/service/AutoUpdateServiceTest.java
@@ -291,4 +291,36 @@ class AutoUpdateServiceTest {
                     "Non-existent directory should not be writable");
         }
     }
+
+    @Nested
+    @DisplayName("PowerShell Argument Escaping Tests")
+    class PowerShellEscapingTests {
+
+        @Test
+        @DisplayName("Doubles embedded single quotes so paths cannot break out of quoting")
+        void escapesSingleQuotes() {
+            // e.g. a Windows user named "O'Brien": C:\Users\O'Brien\AppData\Local\Temp\helper.exe
+            String path = "C:\\Users\\O'Brien\\AppData\\Local\\Temp\\fxt-helper.exe";
+            String escaped = AutoUpdateServiceImpl.escapePowerShellSingleQuoted(path);
+
+            assertEquals("C:\\Users\\O''Brien\\AppData\\Local\\Temp\\fxt-helper.exe", escaped);
+            // When wrapped in single quotes, no lone single quote may survive.
+            String wrapped = "'" + escaped + "'";
+            assertFalse(wrapped.contains("O'Brien"),
+                    "A lone single quote must not survive: " + wrapped);
+        }
+
+        @Test
+        @DisplayName("Leaves quote-free paths unchanged")
+        void leavesNormalPathsUnchanged() {
+            String path = "C:\\Users\\karl\\AppData\\Local\\Temp\\fxt-helper.exe";
+            assertEquals(path, AutoUpdateServiceImpl.escapePowerShellSingleQuoted(path));
+        }
+
+        @Test
+        @DisplayName("Handles null defensively")
+        void handlesNull() {
+            assertEquals("", AutoUpdateServiceImpl.escapePowerShellSingleQuoted(null));
+        }
+    }
 }

--- a/src/test/java/org/fxt/freexmltoolkit/service/ConnectionServiceTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/service/ConnectionServiceTest.java
@@ -370,4 +370,28 @@ class ConnectionServiceTest {
         assertEquals(200, result.httpStatus(), "Should complete before timeout");
         assertTrue(result.duration() < 30000, "Should complete well before 30s timeout");
     }
+
+    @Test
+    @DisplayName("trustAllCerts must NOT poison the JVM-global HTTPS defaults")
+    void trustAllCerts_doesNotModifyGlobalSslDefaults() {
+        // SECURITY: enabling the SSL bypass for a connection test must not disable certificate
+        // validation process-wide. Otherwise unrelated HTTPS connections (e.g. auto-update
+        // downloads) would silently inherit a trust-all SSL context.
+        var beforeFactory = javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory();
+        var beforeVerifier = javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier();
+
+        Properties props = new Properties();
+        props.setProperty("ssl.trustAllCerts", "true");
+        props.setProperty("manualProxy", "false");
+        props.setProperty("useSystemProxy", "false");
+
+        // Target an unreachable HTTPS endpoint - the request fails, but the SSL configuration
+        // (the part under test) runs regardless of connection success.
+        connectionService.testHttpRequest(URI.create("https://127.0.0.1:1/"), props);
+
+        assertSame(beforeFactory, javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory(),
+                "Global default SSLSocketFactory must not be replaced by trustAllCerts");
+        assertSame(beforeVerifier, javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier(),
+                "Global default HostnameVerifier must not be replaced by trustAllCerts");
+    }
 }

--- a/src/test/java/org/fxt/freexmltoolkit/service/FOPServiceTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/service/FOPServiceTest.java
@@ -455,6 +455,64 @@ class FOPServiceTest {
         assertTrue(result.length() > 100, "Complex PDF should have substantial size");
     }
 
+    // ===== SECURITY TESTS =====
+
+    @Test
+    @DisplayName("Should block remote fo:external-graphic (SSRF) without a network call")
+    void testBlocksRemoteExternalGraphic() throws Exception {
+        // A malicious FO referencing a remote image must not cause FOP to reach out over the
+        // network. The hardened resource resolver rejects the reference immediately; FOP logs the
+        // missing image and still produces a PDF. We assert the run completes quickly (no network
+        // connect attempt to the non-routable address).
+        String xmlContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <document><content>Test</content></document>
+            """;
+
+        String xslContent = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format">
+                <xsl:template match="/">
+                    <fo:root>
+                        <fo:layout-master-set>
+                            <fo:simple-page-master master-name="A4"
+                                page-height="297mm" page-width="210mm" margin="20mm">
+                                <fo:region-body/>
+                            </fo:simple-page-master>
+                        </fo:layout-master-set>
+                        <fo:page-sequence master-reference="A4">
+                            <fo:flow flow-name="xsl-region-body">
+                                <fo:block>
+                                    <fo:external-graphic src="url('http://169.254.169.254/evil.png')"/>
+                                </fo:block>
+                            </fo:flow>
+                        </fo:page-sequence>
+                    </fo:root>
+                </xsl:template>
+            </xsl:stylesheet>
+            """;
+
+        Path xmlFile = tempDir.resolve("ssrf.xml");
+        Path xslFile = tempDir.resolve("ssrf.xsl");
+        Path pdfFile = tempDir.resolve("ssrf.pdf");
+        Files.writeString(xmlFile, xmlContent);
+        Files.writeString(xslFile, xslContent);
+
+        PDFSettings settings = new PDFSettings(new HashMap<>(), "", "", "", "", "", "");
+
+        long start = System.currentTimeMillis();
+        File result = fopService.createPdfFile(xmlFile.toFile(), xslFile.toFile(), pdfFile.toFile(), settings);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertNotNull(result);
+        assertTrue(result.exists(), "PDF should still be produced (with the remote image omitted)");
+        assertTrue(elapsed < 15000,
+                "Remote image must be blocked immediately, not fetched over the network (took "
+                        + elapsed + " ms)");
+    }
+
     // ===== FAILURE SCENARIO TESTS =====
 
     @Test


### PR DESCRIPTION
## Security hardening from a full application security audit

Addresses all seven findings from a security audit of the XML-processing
attack surface (untrusted XML/XSD/XSLT/Schematron/FO files, the auto-update
channel, and network/SSL handling). Each fix is an isolated commit with an
explanatory message and dedicated tests; all affected areas were regression-tested.

### Fixes

| # | Finding | Fix |
|---|---------|-----|
| **1** | Update download had **no integrity verification** | Verify the downloaded artifact against the SHA-256 digest GitHub publishes for the release asset (fetched over TLS); abort + delete on mismatch. Enforce strictly via `update.requireChecksum=true`. |
| **2** | `ssl.trustAllCerts` poisoned the **JVM-global** HTTPS defaults (affected update downloads) | Trust-all bypass is now scoped to the single connection under test; global `HttpsURLConnection` defaults are never modified. |
| **3** | Multiple `SchemaFactory` instances had **no XXE/SSRF hardening** | Central `SecureXmlFactory.createSecureSchemaFactory(...)` (secure processing, no external DTD, restricted schema protocols) **plus an active `LSResourceResolver`** that blocks remote references — because the bundled exist-db Xerces fork ignores the JAXP `ACCESS_EXTERNAL_SCHEMA` property. |
| **4** | XSLT/XQuery `doc()`/`document()`/`unparsed-text()` could reach internal/remote URLs (SSRF, exfiltration) | Saxon `ResourceResolver` + `UnparsedTextURIResolver` block http/https/ftp while preserving local resolution. |
| **5** | Apache FOP loaded **external resources** from FO/SVG (`fo:external-graphic`, `xlink:href`) | `FopFactoryBuilder` with a `ResourceResolver` that rejects remote protocols; local images still resolve. |
| **6** | **Stored XSS** in generated XSD docs | Escape schema-derived namespace prefix/URI in `getNameSpacesAsString()`; render `xs:appinfo` text via `th:text`. |
| **7** | PowerShell UAC elevation built its command via unescaped string concatenation | Properly escape paths for PowerShell single-quoted literals (doubling quotes). |

### Notes discovered during the work

- **Finding #3 was more serious than reported:** the bundled Xerces fork silently ignores `ACCESS_EXTERNAL_SCHEMA`. A property-only fix would have been ineffective (proven by a blocked `xs:include` still attempting a ~130s network connect). The fix uses an active resolver instead; the same SSRF test now completes in ~0.006s.
- **Several reported XSS/SSRF items were false positives** and were deliberately **not** changed, to avoid breaking functionality: the Schematron WebView/HTML path already escapes every leaf via `escapeHtml`; most `th:utext` usages render intentional, already-escaped HTML (breadcrumbs, javadoc links, formatted namespaces, SVG diagrams); SVG element names are already escaped via `escapeXml`. Only the two genuine leaks were fixed.

### Testing

New/extended tests accompany each fix (SchemaFactory hardening, SSL global-default invariant, XSLT/XQuery + FOP remote-block timing assertions, namespace XSS escaping, PowerShell escaping). Affected suites pass: SecureXmlFactory, ConnectionService, XsltSecurity, XsltTransformationEngineXQuery, FOPService, XsdDocumentationData, AutoUpdateService, and schema/validation regression sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
