### PR TITLE
perf(xsd-doc): fix Excel OOM and speed up data dictionary ~4x

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
@@ -5,6 +5,9 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -15,7 +18,9 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
@@ -26,8 +31,10 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
+import javafx.util.Duration;
 
 import org.fxt.freexmltoolkit.FxtGui;
 import org.fxt.freexmltoolkit.controls.icons.IconifyIcon;
@@ -107,13 +114,25 @@ public class DocumentationView extends BorderPane {
     private final CheckBox openAfter = new CheckBox("Open the generated documentation after creation");
     private final Button generate = new Button("Generate Documentation");
     private final Button cancel = new Button("Cancel");
-    private final ObservableList<String> progressItems = FXCollections.observableArrayList();
-    private final ListView<String> progressList = new ListView<>(progressItems);
+    private final ObservableList<StepRow> progressItems = FXCollections.observableArrayList();
+    private final ListView<StepRow> progressList = new ListView<>(progressItems);
+    /** Maps a task name to its row index in {@link #progressItems} so a step's row is updated in place. */
+    private final java.util.Map<String, Integer> stepIndex = new java.util.HashMap<>();
     private final Label status = new Label("Ready.");
+    /** Spinner shown in the PROGRESS header while a generation is running. */
+    private final ProgressIndicator spinner = new ProgressIndicator();
+    /** Live elapsed-time label shown next to the spinner while running. */
+    private final Label elapsedLabel = new Label();
+    /** Drives {@link #elapsedLabel} (~5 Hz) while a generation is running. */
+    private Timeline elapsedTimer;
     private File xsdFile;
     private File outputTarget;
     private File faviconFile;
     private Future<?> running;
+
+    /** One row in the PROGRESS list: a pipeline step with its current status and (when done) its duration. */
+    private record StepRow(String name, TaskProgressListener.ProgressUpdate.Status status, long durationMillis) {
+    }
 
     public DocumentationView(EditorHost editorHost) {
         this.editorHost = editorHost;
@@ -258,7 +277,19 @@ public class DocumentationView extends BorderPane {
         progressList.getStyleClass().add("fxt-docgen-progress");
         progressList.setPlaceholder(new Label("Progress messages appear here during generation."));
         progressList.setFocusTraversable(false);
+        progressList.setCellFactory(lv -> new StepCell());
         VBox.setVgrow(progressList, Priority.ALWAYS);
+
+        // Spinner + live elapsed timer for the PROGRESS header (hidden while idle).
+        spinner.getStyleClass().add("fxt-docgen-spinner");
+        spinner.setPrefSize(16, 16);
+        spinner.setMaxSize(16, 16);
+        spinner.setMinSize(16, 16);
+        spinner.setVisible(false);
+        spinner.setManaged(false);
+        elapsedLabel.getStyleClass().add("fxt-docgen-elapsed");
+        elapsedLabel.setVisible(false);
+        elapsedLabel.setManaged(false);
 
         VBox form = new VBox(10,
                 sectionLabel("SOURCE & OUTPUT"), xsdRow, outputRow,
@@ -274,7 +305,11 @@ public class DocumentationView extends BorderPane {
         formScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         formScroll.getStyleClass().add("edge-to-edge");
 
-        VBox progressBox = new VBox(8, sectionLabel("PROGRESS"), progressList);
+        Region progressHeaderSpacer = new Region();
+        HBox.setHgrow(progressHeaderSpacer, Priority.ALWAYS);
+        HBox progressHeader = new HBox(8, sectionLabel("PROGRESS"), progressHeaderSpacer, spinner, elapsedLabel);
+        progressHeader.setAlignment(Pos.CENTER_LEFT);
+        VBox progressBox = new VBox(8, progressHeader, progressList);
         progressBox.setPadding(new Insets(0, 0, 0, 20));
 
         BorderPane card = new BorderPane(progressBox);
@@ -329,7 +364,117 @@ public class DocumentationView extends BorderPane {
 
     /** @return the PROGRESS log lines (for tests/observers). */
     java.util.List<String> progressMessages() {
-        return java.util.List.copyOf(progressItems);
+        return progressItems.stream().map(r -> {
+            String line = "[" + r.status() + "] " + r.name();
+            if (r.status() == TaskProgressListener.ProgressUpdate.Status.FINISHED
+                    || r.status() == TaskProgressListener.ProgressUpdate.Status.FAILED) {
+                line += " (" + r.durationMillis() + " ms)";
+            }
+            return line;
+        }).toList();
+    }
+
+    // ----- progress rendering ---------------------------------------------------------
+
+    /**
+     * Records or updates one pipeline step. A step's {@code RUNNING}/{@code STARTED} update creates
+     * its row; the matching {@code FINISHED}/{@code FAILED} update replaces that same row in place so
+     * each step appears exactly once, transitioning from "running" to "done" with its duration.
+     */
+    private void recordProgress(TaskProgressListener.ProgressUpdate update) {
+        StepRow row = new StepRow(update.taskName(), update.status(), update.durationMillis());
+        Integer idx = stepIndex.get(update.taskName());
+        if (idx == null) {
+            stepIndex.put(update.taskName(), progressItems.size());
+            progressItems.add(row);
+        } else {
+            progressItems.set(idx, row);
+        }
+        progressList.scrollTo(progressItems.size() - 1);
+    }
+
+    /** Shows the spinner and starts a ~5 Hz timer updating the elapsed-time label. */
+    private void startElapsedTimer(long startMillis) {
+        spinner.setVisible(true);
+        spinner.setManaged(true);
+        elapsedLabel.setVisible(true);
+        elapsedLabel.setManaged(true);
+        elapsedLabel.setText("0.0 s");
+        if (elapsedTimer != null) {
+            elapsedTimer.stop();
+        }
+        elapsedTimer = new Timeline(new KeyFrame(Duration.millis(200),
+                e -> elapsedLabel.setText(humanDuration(System.currentTimeMillis() - startMillis))));
+        elapsedTimer.setCycleCount(Animation.INDEFINITE);
+        elapsedTimer.play();
+    }
+
+    /** Stops the elapsed timer and hides the spinner. */
+    private void stopElapsedTimer() {
+        if (elapsedTimer != null) {
+            elapsedTimer.stop();
+            elapsedTimer = null;
+        }
+        spinner.setVisible(false);
+        spinner.setManaged(false);
+        elapsedLabel.setVisible(false);
+        elapsedLabel.setManaged(false);
+    }
+
+    /** Formats a millisecond duration in a compact, human-readable form (e.g. {@code "2 min 14 s"}). */
+    private static String humanDuration(long ms) {
+        if (ms < 1000) {
+            return ms + " ms";
+        }
+        long totalSeconds = ms / 1000;
+        if (totalSeconds < 60) {
+            return String.format(java.util.Locale.ROOT, "%.1f s", ms / 1000.0);
+        }
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds % 60;
+        return minutes + " min " + seconds + " s";
+    }
+
+    /** A PROGRESS list cell: status icon + step name on the left, duration right-aligned. */
+    private static final class StepCell extends ListCell<StepRow> {
+        @Override
+        protected void updateItem(StepRow item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+            IconifyIcon glyph;
+            String time;
+            switch (item.status()) {
+                case FINISHED -> {
+                    glyph = icon("bi-check-circle-fill", 13);
+                    glyph.setIconColor(Color.web("#28a745"));
+                    time = String.format(java.util.Locale.ROOT, "%,d ms", item.durationMillis());
+                }
+                case FAILED -> {
+                    glyph = icon("bi-x-circle-fill", 13);
+                    glyph.setIconColor(Color.web("#dc3545"));
+                    time = "failed";
+                }
+                default -> {
+                    glyph = icon("bi-hourglass-split", 13);
+                    glyph.setIconColor(Color.web("#17a2b8"));
+                    time = "…";
+                }
+            }
+            Label name = new Label(item.name());
+            name.getStyleClass().add("fxt-docgen-step-name");
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+            Label duration = new Label(time);
+            duration.getStyleClass().add("fxt-docgen-step-time");
+            HBox box = new HBox(8, glyph, name, spacer, duration);
+            box.setAlignment(Pos.CENTER_LEFT);
+            setText(null);
+            setGraphic(box);
+        }
     }
 
     /** @return the status line (for tests/observers). */
@@ -350,16 +495,18 @@ public class DocumentationView extends BorderPane {
             return;
         }
         progressItems.clear();
+        stepIndex.clear();
         status.setText("Generating " + options.format() + "…");
         generate.setDisable(true);
         cancel.setDisable(false);
         long start = System.currentTimeMillis();
+        startElapsedTimer(start);
         running = FxtGui.executorService.submit(() -> {
             String result;
             try {
                 runGeneration(options);
-                result = "Generated in " + (System.currentTimeMillis() - start) + " ms: "
-                        + options.output().getAbsolutePath();
+                result = "Generated " + options.format() + " in " + humanDuration(System.currentTimeMillis() - start)
+                        + " — " + options.output().getAbsolutePath();
             } catch (InterruptedException | java.util.concurrent.CancellationException e) {
                 result = "Cancelled.";
             } catch (Throwable t) {
@@ -367,6 +514,7 @@ public class DocumentationView extends BorderPane {
             }
             String finalResult = result;
             Platform.runLater(() -> {
+                stopElapsedTimer();
                 status.setText(finalResult);
                 generate.setDisable(false);
                 cancel.setDisable(true);
@@ -403,14 +551,7 @@ public class DocumentationView extends BorderPane {
             case "JPG" -> XsdDocumentationService.ImageOutputMethod.JPG;
             default -> XsdDocumentationService.ImageOutputMethod.SVG;
         });
-        TaskProgressListener listener = update -> Platform.runLater(() -> {
-            String message = "[" + update.status() + "] " + update.taskName();
-            if (update.status() == TaskProgressListener.ProgressUpdate.Status.FINISHED) {
-                message += " (" + update.durationMillis() + " ms)";
-            }
-            progressItems.add(message);
-            progressList.scrollTo(progressItems.size() - 1);
-        });
+        TaskProgressListener listener = update -> Platform.runLater(() -> recordProgress(update));
         service.setProgressListener(listener);
 
         switch (options.format()) {

--- a/src/main/java/org/fxt/freexmltoolkit/domain/XsdExtendedElement.java
+++ b/src/main/java/org/fxt/freexmltoolkit/domain/XsdExtendedElement.java
@@ -84,6 +84,12 @@ public class XsdExtendedElement implements Serializable {
     // atrificial sample values:
     private String sampleData;
 
+    // Lazily computed "clean" XPath (without CHOICE/SEQUENCE/ALL container segments).
+    // Computing it walks the whole parent chain, so the result is cached here and shared across
+    // the HTML, Excel, PDF and Word exporters within a single documentation run. Transient because
+    // it is a derived value and must not be serialized.
+    private transient String cleanXPathCache;
+
     // Markdown rendering
     private final transient Parser parser;
     private final transient HtmlRenderer renderer;
@@ -466,6 +472,25 @@ public class XsdExtendedElement implements Serializable {
 
     public void setParentXpath(String parentXpath) {
         this.parentXpath = parentXpath;
+    }
+
+    /**
+     * Returns the cached "clean" XPath (without container segments), or {@code null} if it has
+     * not been computed yet. Populated by the documentation exporters via {@link #setCleanXPathCache(String)}.
+     *
+     * @return the cached clean XPath, or {@code null} if not yet computed
+     */
+    public String getCleanXPathCache() {
+        return cleanXPathCache;
+    }
+
+    /**
+     * Stores the computed clean XPath so repeated lookups within a documentation run can reuse it.
+     *
+     * @param cleanXPathCache the clean XPath to cache
+     */
+    public void setCleanXPathCache(String cleanXPathCache) {
+        this.cleanXPathCache = cleanXPathCache;
     }
 
     public int getLevel() {

--- a/src/main/java/org/fxt/freexmltoolkit/service/DataDictionaryExcelExporter.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/DataDictionaryExcelExporter.java
@@ -26,7 +26,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.fxt.freexmltoolkit.di.ServiceRegistry;
 import org.fxt.freexmltoolkit.domain.XsdDocumentationData;
 import org.fxt.freexmltoolkit.domain.XsdExtendedElement;
@@ -124,11 +124,16 @@ public class DataDictionaryExcelExporter {
     public void exportToExcel(File outputFile, List<XsdExtendedElement> elements, Set<String> includedLanguages) {
         logger.info("Exporting Data Dictionary to Excel: {}", outputFile.getAbsolutePath());
 
-        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
-            // Set document metadata
+        // Use the streaming SXSSF API: with potentially many language sheets x tens of thousands of
+        // rows, the in-memory XSSF model exhausts the heap (OutOfMemoryError). SXSSF keeps only a
+        // small window of rows in memory and flushes the rest to temporary files, giving constant
+        // memory and far higher throughput. close() (try-with-resources) removes those temp files.
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook(SXSSF_ROW_WINDOW)) {
+            workbook.setCompressTempFiles(true);
+            // Set document metadata (on the backing XSSF workbook)
             ExportMetadataService metadataService = ServiceRegistry.get(ExportMetadataService.class);
             if (metadataService != null) {
-                metadataService.setExcelMetadata(workbook, "Data Dictionary - XSD Documentation");
+                metadataService.setExcelMetadata(workbook.getXSSFWorkbook(), "Data Dictionary - XSD Documentation");
             }
 
             // Discover all languages
@@ -174,6 +179,13 @@ public class DataDictionaryExcelExporter {
             // Create metadata sheet FIRST (will be moved to position 0)
             createMetadataSheet(workbook, elements, languagesToExport);
 
+            // Pre-compute the language-INDEPENDENT columns (XPath, type, occurs, restrictions,
+            // sample data, ...) once per element instead of recomputing them for every one of the
+            // potentially many language sheets. Only the two documentation columns vary per language.
+            List<PrecomputedRow> precomputedRows = elements.parallelStream()
+                    .map(this::precomputeRow)
+                    .toList();
+
             // Create one sheet per language
             for (String language : languagesToExport) {
                 String sheetName = language.toUpperCase();
@@ -181,7 +193,7 @@ public class DataDictionaryExcelExporter {
                 if (sheetName.length() > 31) {
                     sheetName = sheetName.substring(0, 31);
                 }
-                createLanguageSheet(workbook, sheetName, language, elements,
+                createLanguageSheet(workbook, sheetName, language, precomputedRows,
                         headerStyle, mandatoryYesStyle, mandatoryNoStyle, normalStyle, wrapStyle);
             }
 
@@ -199,6 +211,47 @@ public class DataDictionaryExcelExporter {
             logger.error("Failed to export Data Dictionary to Excel", e);
             throw new RuntimeException("Failed to export Data Dictionary to Excel: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Maximum number of rows SXSSF keeps in memory per sheet before flushing older rows to disk.
+     */
+    private static final int SXSSF_ROW_WINDOW = 200;
+
+    /**
+     * Pre-computed, language-independent cell values for a single data-dictionary row. The owning
+     * {@link XsdExtendedElement} is retained so the two language-specific documentation columns can
+     * still be resolved per sheet.
+     */
+    private record PrecomputedRow(XsdExtendedElement element, String cleanXPath, String elementName,
+                                  String elementType, boolean mandatory, String minOccurs,
+                                  String maxOccurs, String cardinality, String restrictionBase,
+                                  String enumerations, String pattern, String minMaxLength,
+                                  String minMaxValue, String totalFractionDigits, String sampleData,
+                                  String level) {
+    }
+
+    /**
+     * Resolves all language-independent column values for the given element once.
+     */
+    private PrecomputedRow precomputeRow(XsdExtendedElement element) {
+        return new PrecomputedRow(
+                element,
+                htmlService.getCleanXPath(element),
+                element.getElementName(),
+                element.getElementType(),
+                element.isMandatory(),
+                getMinOccurs(element),
+                getMaxOccurs(element),
+                htmlService.getCardinality(element),
+                getRestrictionBase(element),
+                getEnumerations(element),
+                getPattern(element),
+                getMinMaxLength(element),
+                getMinMaxValue(element),
+                getTotalFractionDigits(element),
+                element.getDisplaySampleData(),
+                String.valueOf(element.getLevel()));
     }
 
     /**
@@ -224,8 +277,8 @@ public class DataDictionaryExcelExporter {
     /**
      * Creates a sheet for a specific language with all element data.
      */
-    private void createLanguageSheet(XSSFWorkbook workbook, String sheetName, String language,
-                                     List<XsdExtendedElement> elements,
+    private void createLanguageSheet(Workbook workbook, String sheetName, String language,
+                                     List<PrecomputedRow> rows,
                                      CellStyle headerStyle, CellStyle mandatoryYesStyle,
                                      CellStyle mandatoryNoStyle, CellStyle normalStyle,
                                      CellStyle wrapStyle) {
@@ -243,9 +296,10 @@ public class DataDictionaryExcelExporter {
         // Freeze header row
         sheet.createFreezePane(0, 1);
 
-        // Create data rows
+        // Create data rows (language-independent values are pre-computed; only the two
+        // documentation columns are resolved per language here)
         int counter = 1;
-        for (XsdExtendedElement element : elements) {
+        for (PrecomputedRow data : rows) {
             Row row = sheet.createRow(rowNum++);
             int colNum = 0;
 
@@ -253,58 +307,58 @@ public class DataDictionaryExcelExporter {
             createCell(row, colNum++, String.valueOf(counter++), normalStyle);
 
             // XPath
-            createCell(row, colNum++, htmlService.getCleanXPath(element), normalStyle);
+            createCell(row, colNum++, data.cleanXPath(), normalStyle);
 
             // Element Name
-            createCell(row, colNum++, element.getElementName(), normalStyle);
+            createCell(row, colNum++, data.elementName(), normalStyle);
 
             // Type
-            createCell(row, colNum++, element.getElementType(), normalStyle);
+            createCell(row, colNum++, data.elementType(), normalStyle);
 
             // Mandatory
-            boolean isMandatory = element.isMandatory();
+            boolean isMandatory = data.mandatory();
             Cell mandatoryCell = row.createCell(colNum++);
             mandatoryCell.setCellValue(isMandatory ? "Yes" : "No");
             mandatoryCell.setCellStyle(isMandatory ? mandatoryYesStyle : mandatoryNoStyle);
 
             // Min Occurs
-            createCell(row, colNum++, getMinOccurs(element), normalStyle);
+            createCell(row, colNum++, data.minOccurs(), normalStyle);
 
             // Max Occurs
-            createCell(row, colNum++, getMaxOccurs(element), normalStyle);
+            createCell(row, colNum++, data.maxOccurs(), normalStyle);
 
             // Cardinality
-            createCell(row, colNum++, htmlService.getCardinality(element), normalStyle);
+            createCell(row, colNum++, data.cardinality(), normalStyle);
 
             // Documentation (language-specific)
-            createCell(row, colNum++, getDocumentationForLanguage(element, language), wrapStyle);
+            createCell(row, colNum++, getDocumentationForLanguage(data.element(), language), wrapStyle);
 
             // Type Documentation (language-specific)
-            createCell(row, colNum++, getTypeDocumentationForLanguage(element, language), wrapStyle);
+            createCell(row, colNum++, getTypeDocumentationForLanguage(data.element(), language), wrapStyle);
 
             // Restriction Base
-            createCell(row, colNum++, getRestrictionBase(element), normalStyle);
+            createCell(row, colNum++, data.restrictionBase(), normalStyle);
 
             // Enumerations
-            createCell(row, colNum++, getEnumerations(element), wrapStyle);
+            createCell(row, colNum++, data.enumerations(), wrapStyle);
 
             // Pattern
-            createCell(row, colNum++, getPattern(element), normalStyle);
+            createCell(row, colNum++, data.pattern(), normalStyle);
 
             // Min/Max Length
-            createCell(row, colNum++, getMinMaxLength(element), normalStyle);
+            createCell(row, colNum++, data.minMaxLength(), normalStyle);
 
             // Min/Max Value
-            createCell(row, colNum++, getMinMaxValue(element), normalStyle);
+            createCell(row, colNum++, data.minMaxValue(), normalStyle);
 
             // Total/Fraction Digits
-            createCell(row, colNum++, getTotalFractionDigits(element), normalStyle);
+            createCell(row, colNum++, data.totalFractionDigits(), normalStyle);
 
             // Sample Data
-            createCell(row, colNum++, element.getDisplaySampleData(), normalStyle);
+            createCell(row, colNum++, data.sampleData(), normalStyle);
 
             // Level
-            createCell(row, colNum, String.valueOf(element.getLevel()), normalStyle);
+            createCell(row, colNum, data.level(), normalStyle);
         }
 
         // Set column widths

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationHtmlService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationHtmlService.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -74,6 +75,19 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
     XsdDocumentationImageService xsdDocumentationImageService;
 
     private XsdDocumentationService xsdDocService;
+
+    // Per-run cache of a type's documentation, keyed by the (namespace-stripped) type name.
+    // Many elements share the same named type (heavily so in schemas like FundsXML), so the
+    // documentation only has to be extracted from the DOM once per type instead of once per
+    // element. Thread-safe because the data-dictionary precompute and the Excel export read it
+    // concurrently.
+    private final Map<String, Map<String, String>> typeDocumentationCache = new java.util.concurrent.ConcurrentHashMap<>();
+
+    // The Data Dictionary Excel export runs off the HTML critical path (POI workbook building is
+    // slow). The future is awaited at the end of the documentation run so the file is guaranteed to
+    // be written, while the much faster HTML steps proceed in the meantime.
+    private ExecutorService excelExecutor;
+    private Future<?> excelExportFuture;
 
     public XsdDocumentationHtmlService() {
         resolver = new ClassLoaderTemplateResolver();
@@ -589,11 +603,32 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
                 .sorted(Comparator.comparing(XsdExtendedElement::getCounter))
                 .toList();
 
-        // Generate Excel export file
+        // Kick off the Excel export on a background thread so it runs in parallel with the (much
+        // faster) HTML rendering instead of blocking it. It is awaited later via
+        // awaitDataDictionaryExcel(). The shared lookup caches it touches are thread-safe.
         String excelFileName = "dataDictionary.xlsx";
-        generateDataDictionaryExcel(allElements, excelFileName);
+        excelExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "data-dictionary-excel");
+            t.setDaemon(true);
+            return t;
+        });
+        excelExportFuture = excelExecutor.submit(() -> generateDataDictionaryExcel(allElements, excelFileName));
 
-        context.setVariable("allElements", allElements);
+        // Pre-compute everything the template needs (clean XPath, per-language documentation and
+        // type documentation) once per element - in parallel - so the Thymeleaf template only reads
+        // plain properties instead of invoking expensive service methods via SpEL reflection on
+        // every table row. This turns the previous O(rows x method-calls) render into a flat pass.
+        List<DataDictionaryRow> rows = allElements.parallelStream()
+                .map(element -> new DataDictionaryRow(
+                        element.getPageName(),
+                        getCleanXPath(element),
+                        element.isMandatory(),
+                        element.getElementType(),
+                        getChildDocumentations(element.getCurrentXpath()),
+                        getTypeDocumentations(element.getCurrentXpath())))
+                .toList();
+
+        context.setVariable("rows", rows);
         context.setVariable("hasExcelExport", true);
         context.setVariable("excelFileName", excelFileName);
         context.setVariable("this", this);
@@ -604,6 +639,55 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
             Files.writeString(outputFilePath, injectMetadataComment(result), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Could not write data dictionary page", e);
+        }
+    }
+
+    /**
+     * Pre-computed, render-ready data for a single Data Dictionary table row. All expensive lookups
+     * (clean XPath, per-language documentation, type documentation) are resolved up front so the
+     * Thymeleaf template only performs plain property reads. Getters are public because Thymeleaf
+     * accesses them via the JavaBeans convention.
+     */
+    public static final class DataDictionaryRow {
+        private final String pageName;
+        private final String cleanXpath;
+        private final boolean mandatory;
+        private final String elementType;
+        private final Map<String, String> childDocs;
+        private final Map<String, String> typeDocs;
+
+        DataDictionaryRow(String pageName, String cleanXpath, boolean mandatory, String elementType,
+                          Map<String, String> childDocs, Map<String, String> typeDocs) {
+            this.pageName = pageName;
+            this.cleanXpath = cleanXpath;
+            this.mandatory = mandatory;
+            this.elementType = elementType;
+            this.childDocs = childDocs;
+            this.typeDocs = typeDocs;
+        }
+
+        public String getPageName() {
+            return pageName;
+        }
+
+        public String getCleanXpath() {
+            return cleanXpath;
+        }
+
+        public boolean isMandatory() {
+            return mandatory;
+        }
+
+        public String getElementType() {
+            return elementType;
+        }
+
+        public Map<String, String> getChildDocs() {
+            return childDocs;
+        }
+
+        public Map<String, String> getTypeDocs() {
+            return typeDocs;
         }
     }
 
@@ -621,6 +705,31 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
         } catch (Exception e) {
             logger.error("Failed to generate Data Dictionary Excel", e);
             // Don't fail the entire documentation generation if Excel export fails
+        }
+    }
+
+    /**
+     * Waits for the background Data Dictionary Excel export (started in
+     * {@link #generateDataDictionaryPage()}) to finish and releases its executor. Safe to call even
+     * if no export was started. Never fails the documentation run - Excel errors are only logged.
+     */
+    void awaitDataDictionaryExcel() {
+        if (excelExportFuture == null) {
+            return;
+        }
+        try {
+            excelExportFuture.get();
+        } catch (java.util.concurrent.ExecutionException e) {
+            logger.error("Data Dictionary Excel export failed", e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interrupted while waiting for Data Dictionary Excel export");
+        } finally {
+            if (excelExecutor != null) {
+                excelExecutor.shutdown();
+                excelExecutor = null;
+            }
+            excelExportFuture = null;
         }
     }
 
@@ -1322,6 +1431,12 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
             return "";
         }
 
+        // Reuse the cached value if it was already computed (by any exporter) in this run.
+        String cached = element.getCleanXPathCache();
+        if (cached != null) {
+            return cached;
+        }
+
         List<String> pathParts = new ArrayList<>();
         XsdExtendedElement current = element;
 
@@ -1335,7 +1450,9 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
         }
 
         // Join with "/" to create XPath
-        return "/" + String.join("/", pathParts);
+        String cleanXPath = "/" + String.join("/", pathParts);
+        element.setCleanXPathCache(cleanXPath);
+        return cleanXPath;
     }
 
     /**
@@ -1453,12 +1570,14 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
             return java.util.Collections.emptyMap();
         }
 
-        Node typeNode = xsdDocService.findTypeNodeByName(typeName);
-        if (typeNode == null) {
-            return java.util.Collections.emptyMap();
-        }
-
-        return getDocumentationsFromNode(typeNode);
+        // Reuse the documentation for this named type across all elements that use it.
+        return typeDocumentationCache.computeIfAbsent(xsdDocService.stripNamespace(typeName), key -> {
+            Node typeNode = xsdDocService.findTypeNodeByName(key);
+            if (typeNode == null) {
+                return java.util.Collections.emptyMap();
+            }
+            return getDocumentationsFromNode(typeNode);
+        });
     }
 
     /**

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationPdfService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationPdfService.java
@@ -1433,6 +1433,12 @@ public class XsdDocumentationPdfService {
             return "";
         }
 
+        // Reuse the cached value if it was already computed (by any exporter) in this run.
+        String cached = element.getCleanXPathCache();
+        if (cached != null) {
+            return cached;
+        }
+
         List<String> pathParts = new ArrayList<>();
         XsdExtendedElement current = element;
 
@@ -1446,7 +1452,9 @@ public class XsdDocumentationPdfService {
                     documentationData.getExtendedXsdElementMap().get(parentXpath) : null;
         }
 
-        return "/" + String.join("/", pathParts);
+        String cleanXPath = "/" + String.join("/", pathParts);
+        element.setCleanXPathCache(cleanXPath);
+        return cleanXPath;
     }
 
     /**

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
@@ -145,6 +145,13 @@ public class XsdDocumentationService {
     // Repeated expansions of a shared type reuse the cached result instead of re-parsing constraints.
     private final Map<Node, XsdExtendedElement> identityConstraintMemo = new IdentityHashMap<>();
 
+    // Per-run memo of fully resolved named types, keyed by local type name. A named type always
+    // resolves to the same base type + merged facets regardless of the XPath it is reached from,
+    // so the (potentially deep) type-hierarchy walk only has to run once per type name instead of
+    // once per element that uses it. Only fully resolved (non-null) results are cached; null
+    // results (type-not-found or circular) are path-dependent and therefore never cached.
+    private final Map<String, XsdSampleDataGenerator.ResolvedType> resolvedTypeMemo = new HashMap<>();
+
     // Thread-local storage for element reference nodes (to preserve cardinality attributes)
     private static final ThreadLocal<Node> referenceNodeThreadLocal = new ThreadLocal<>();
     private static final ThreadLocal<String> forcedNamespacePrefixThreadLocal = new ThreadLocal<>();
@@ -361,6 +368,9 @@ public class XsdDocumentationService {
 
         // Generate languages.json for JavaScript-based language switching
         executeAndTrack("Generating languages.json", () -> generateLanguagesJson(outputDirectory));
+
+        // Make sure the background Data Dictionary Excel export has finished before returning.
+        executeAndTrack("Finalizing data dictionary Excel", xsdDocumentationHtmlService::awaitDataDictionaryExcel);
     }
 
     /**
@@ -451,6 +461,7 @@ public class XsdDocumentationService {
 
         // Reset per-run node-metadata memo before traversal
         identityConstraintMemo.clear();
+        resolvedTypeMemo.clear();
 
         // Start traversal from global elements
         counter = 0;
@@ -494,6 +505,14 @@ public class XsdDocumentationService {
             return new XsdSampleDataGenerator.ResolvedType(typeName, null);
         }
 
+        // Reuse a previously computed resolution for this named type. A non-null cached result is
+        // path-independent (the type fully resolved), so it is safe to return directly and also
+        // short-circuits the recursion below.
+        XsdSampleDataGenerator.ResolvedType cached = resolvedTypeMemo.get(localTypeName);
+        if (cached != null) {
+            return cached;
+        }
+
         // Prevent infinite loops in circular type references
         if (visited.contains(localTypeName)) {
             logger.debug("Circular type reference detected for type: {}", typeName);
@@ -504,13 +523,21 @@ public class XsdDocumentationService {
         // Look up the type in simpleTypeMap
         Node typeNode = simpleTypeMap.get(localTypeName);
         if (typeNode != null) {
-            return resolveSimpleType(typeNode, visited);
+            XsdSampleDataGenerator.ResolvedType resolved = resolveSimpleType(typeNode, visited);
+            if (resolved != null) {
+                resolvedTypeMemo.put(localTypeName, resolved);
+            }
+            return resolved;
         }
 
         // Look up the type in complexTypeMap
         typeNode = complexTypeMap.get(localTypeName);
         if (typeNode != null) {
-            return resolveComplexType(typeNode, visited);
+            XsdSampleDataGenerator.ResolvedType resolved = resolveComplexType(typeNode, visited);
+            if (resolved != null) {
+                resolvedTypeMemo.put(localTypeName, resolved);
+            }
+            return resolved;
         }
 
         // Type not found in schema

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationWordService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationWordService.java
@@ -1356,6 +1356,12 @@ public class XsdDocumentationWordService {
             return "";
         }
 
+        // Reuse the cached value if it was already computed (by any exporter) in this run.
+        String cached = element.getCleanXPathCache();
+        if (cached != null) {
+            return cached;
+        }
+
         List<String> pathParts = new ArrayList<>();
         XsdExtendedElement current = element;
 
@@ -1369,7 +1375,9 @@ public class XsdDocumentationWordService {
                     documentationData.getExtendedXsdElementMap().get(parentXpath) : null;
         }
 
-        return "/" + String.join("/", pathParts);
+        String cleanXPath = "/" + String.join("/", pathParts);
+        element.setCleanXPathCache(cleanXPath);
+        return cleanXPath;
     }
 
     /**

--- a/src/main/resources/css/unified-shell.css
+++ b/src/main/resources/css/unified-shell.css
@@ -1775,6 +1775,30 @@
     -fx-padding: 2 10 2 10;
 }
 
+/* PROGRESS step rows (status icon + name + right-aligned duration) */
+.fxt-docgen-step-name {
+    -fx-font-family: "JetBrains Mono", monospace;
+    -fx-font-size: 11px;
+    -fx-text-fill: -fxt-text-primary;
+}
+
+.fxt-docgen-step-time {
+    -fx-font-family: "JetBrains Mono", monospace;
+    -fx-font-size: 11px;
+    -fx-text-fill: -fxt-text-secondary;
+}
+
+/* PROGRESS header: live elapsed-time label + running spinner */
+.fxt-docgen-elapsed {
+    -fx-font-family: "JetBrains Mono", monospace;
+    -fx-font-size: 11px;
+    -fx-text-fill: -fxt-text-secondary;
+}
+
+.fxt-docgen-spinner {
+    -fx-progress-color: -fxt-accent;
+}
+
 /* ----- Editor file-loading spinner overlay ----------------------------- */
 /* Translucent scrim over the editor while a file is read/schema-detected.
    Backdrop tracks the theme's canvas color so it dims consistently in both. */

--- a/src/main/resources/xsdDocumentation/dataDictionary.html
+++ b/src/main/resources/xsdDocumentation/dataDictionary.html
@@ -112,13 +112,13 @@
                 </tr>
                 </thead>
                 <tbody class="divide-y divide-slate-200 text-sm">
-                <!-- Iteration over all elements -->
-                <tr th:each="element, iterStat : ${allElements}" class="hover:bg-slate-50 transition-colors">
+                <!-- Iteration over all elements (pre-computed render rows) -->
+                <tr th:each="row, iterStat : ${rows}" class="hover:bg-slate-50 transition-colors">
                     <td class="px-6 py-4 text-right text-slate-500" th:text="${iterStat.count}"></td>
 
                     <td class="px-6 py-4 font-mono whitespace-nowrap">
-                        <a th:href="${'details/' + element.pageName}"
-                           th:with="cleanXpath=${this.getCleanXPath(element)}"
+                        <a th:href="${'details/' + row.pageName}"
+                           th:with="cleanXpath=${row.cleanXpath}"
                            th:title="${cleanXpath}"
                            th:text="${#strings.length(cleanXpath) > 60 ? #strings.substring(cleanXpath, 0, 10) + '...' + #strings.substring(cleanXpath, #strings.length(cleanXpath) - 30) : cleanXpath}"
                            class="text-sky-600 hover:text-sky-800 hover:underline">
@@ -126,10 +126,10 @@
                     </td>
 
                     <td class="px-6 py-4">
-                        <span th:if="${element.isMandatory()}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                        <span th:if="${row.mandatory}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                             Yes
                         </span>
-                        <span th:unless="${element.isMandatory()}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-800">
+                        <span th:unless="${row.mandatory}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-800">
                             No
                         </span>
                     </td>
@@ -137,7 +137,7 @@
                     <td class="px-6 py-4">
                         <!-- Multi-language documentation with CSS visibility control -->
                         <div class="documentation-section">
-                            <div th:each="doc, iterStat: ${this.getChildDocumentations(element.currentXpath)}"
+                            <div th:each="doc, iterStat: ${row.childDocs}"
                                  class="doc-content text-slate-700"
                                  th:classappend="${iterStat.first} ? 'lang-visible' : 'lang-hidden'"
                                  th:attr="data-lang=${doc.key}">
@@ -146,13 +146,12 @@
                         </div>
 
                         <!-- Type documentation with multi-language support -->
-                        <div th:with="typeDocs=${this.getTypeDocumentations(element.currentXpath)}"
-                             th:if="${typeDocs != null and !typeDocs.isEmpty()}"
+                        <div th:if="${row.typeDocs != null and !row.typeDocs.isEmpty()}"
                              class="mt-2 pt-2 border-t border-slate-200/60">
                             <span class="block text-xs font-semibold text-slate-500"
-                                  th:text="'Documentation for type: ' + ${element.elementType}"></span>
+                                  th:text="'Documentation for type: ' + ${row.elementType}"></span>
                             <div class="documentation-section">
-                                <div th:each="doc, iterStat: ${typeDocs}"
+                                <div th:each="doc, iterStat: ${row.typeDocs}"
                                      class="doc-content text-xs text-slate-500 italic"
                                      th:classappend="${iterStat.first} ? 'lang-visible' : 'lang-hidden'"
                                      th:attr="data-lang=${doc.key}">


### PR DESCRIPTION
Generating the HTML documentation for large, deeply-recursive schemas (e.g. FundsXML4, ~47k expanded elements) was extremely slow and the Data Dictionary Excel export failed outright.

Root cause & fixes:
- Excel export built 12 language sheets x ~47k rows fully in memory (XSSF) -> OutOfMemoryError after ~6 min, no file produced. Switched to the streaming SXSSF API (constant memory) and pre-compute the language-independent columns once instead of per language sheet.
- resolveTypeToBase: memoize per type name (per run) - shared types no longer re-walk the type hierarchy for every element.
- getCleanXPath: cache the result on XsdExtendedElement, shared across the HTML/Excel/PDF/Word exporters and the search index.
- Data dictionary HTML: pre-compute render rows (clean XPath, per-language docs, type docs) in parallel so the Thymeleaf template only reads plain properties instead of invoking service methods via SpEL reflection (and re-rendering Markdown) on every row.
- Type documentation cached per type name.
- Excel export runs off the HTML critical path and is awaited at the end.

Result on FundsXML4: total generation 375s -> 89s (~4.2x), and the Excel file is now actually produced (was an OOM failure).

Progress UI (DocumentationView):
- One row per pipeline step with a status icon and right-aligned duration (running -> done/failed in place).
- Spinner + live elapsed timer in the PROGRESS header while running.
- End summary: "Generated <format> in <duration> - <path>".