### PR TITLE
feat(xsd-doc): optional data-dictionary dedup by type + fix scroll-to…

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
@@ -60,7 +60,8 @@ public class DocumentationView extends BorderPane {
     /** All generation options (captured from the form; also built directly by tests). */
     record DocOptions(File xsd, File output, String format,
                       boolean useMarkdown, boolean includeTypeDefs, boolean showDocInSvg,
-                      boolean svgOverview, boolean addMetadata, String imageFormat,
+                      boolean svgOverview, boolean addMetadata, boolean deduplicateDataDictionaryByType,
+                      String imageFormat,
                       Set<String> languages, String fallbackLanguage, boolean openAfter,
                       File favicon, FormatOptions formatOptions) {
     }
@@ -90,6 +91,7 @@ public class DocumentationView extends BorderPane {
     private final CheckBox showDocInSvg = new CheckBox("Show documentation in diagrams");
     private final CheckBox svgOverview = new CheckBox("Generate SVG overview page");
     private final CheckBox addMetadata = new CheckBox("Add metadata in output");
+    private final CheckBox dedupDataDictionary = new CheckBox("Deduplicate data dictionary by type");
     private final ComboBox<String> imageFormat = new ComboBox<>();
     private final FlowPane languagesPane = new FlowPane(10, 6);
     private final ComboBox<String> fallbackLanguage = new ComboBox<>();
@@ -241,8 +243,11 @@ public class DocumentationView extends BorderPane {
         HBox faviconRow = new HBox(8, icon("bi-image", 15), faviconName, faviconSpacer,
                 chooseFavicon, clearFavicon);
         faviconRow.setAlignment(Pos.CENTER_LEFT);
+        dedupDataDictionary.setTooltip(new javafx.scene.control.Tooltip(
+                "List each named complex/simple type only once instead of every recursive occurrence "
+                        + "(elements with a built-in or no type are still listed individually)."));
         VBox optionsBox = new VBox(8, useMarkdown, includeTypeDefs, showDocInSvg, svgOverview,
-                addMetadata, imageLabel, imageFormat, faviconLabel, faviconRow);
+                addMetadata, dedupDataDictionary, imageLabel, imageFormat, faviconLabel, faviconRow);
 
         // --- LANGUAGES -----------------------------------------------------------------------
         Hyperlink scan = new Hyperlink("Scan languages");
@@ -341,7 +346,8 @@ public class DocumentationView extends BorderPane {
                 pageNumbers.isSelected(), pdfBookmarks.isSelected());
         return new DocOptions(xsdFile, outputTarget, selectedFormat(),
                 useMarkdown.isSelected(), includeTypeDefs.isSelected(), showDocInSvg.isSelected(),
-                svgOverview.isSelected(), addMetadata.isSelected(), imageFormat.getValue(),
+                svgOverview.isSelected(), addMetadata.isSelected(), dedupDataDictionary.isSelected(),
+                imageFormat.getValue(),
                 languages, fallbackLanguage.getValue(), openAfter.isSelected(), faviconFile, format);
     }
 
@@ -537,6 +543,7 @@ public class DocumentationView extends BorderPane {
         service.setShowDocumentationInSvg(options.showDocInSvg());
         service.setGenerateSvgOverviewPage(options.svgOverview());
         service.setAddMetadataInOutput(options.addMetadata());
+        service.setDeduplicateDataDictionaryByType(options.deduplicateDataDictionaryByType());
         if (options.languages() != null && !options.languages().isEmpty()) {
             service.setIncludedLanguages(options.languages());
         }

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationHtmlService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationHtmlService.java
@@ -131,6 +131,9 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
     // Favicon configuration for output files
     private String faviconPath = null;
 
+    // When true, the data dictionary lists each named complex/simple type only once.
+    private boolean deduplicateDataDictionaryByType = false;
+
     /**
      * Sets the path to a custom favicon file for HTML documentation.
      * Supported formats: .ico, .png, .svg
@@ -139,6 +142,17 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
      */
     public void setFaviconPath(String faviconPath) {
         this.faviconPath = faviconPath;
+    }
+
+    /**
+     * Sets whether the data dictionary collapses each named complex/simple type to a single
+     * representative row (the first occurrence). Elements with a built-in or no type are always
+     * listed individually.
+     *
+     * @param deduplicateDataDictionaryByType {@code true} to deduplicate by named type
+     */
+    public void setDeduplicateDataDictionaryByType(boolean deduplicateDataDictionaryByType) {
+        this.deduplicateDataDictionaryByType = deduplicateDataDictionaryByType;
     }
 
     /**
@@ -598,10 +612,30 @@ public class XsdDocumentationHtmlService implements org.fxt.freexmltoolkit.servi
     void generateDataDictionaryPage() {
         final var context = new Context();
         // Filter out container elements (SEQUENCE, CHOICE, ALL) - they are internal structures
-        List<XsdExtendedElement> allElements = xsdDocumentationData.getExtendedXsdElementMap().values().stream()
+        List<XsdExtendedElement> filtered = xsdDocumentationData.getExtendedXsdElementMap().values().stream()
                 .filter(this::isNotContainerElement)
                 .sorted(Comparator.comparing(XsdExtendedElement::getCounter))
                 .toList();
+
+        // Optionally collapse the recursive explosion: list each named complex/simple type only
+        // once (its first occurrence by counter). Elements with a built-in (xs:*) or no type are
+        // always kept individually, so leaf fields are not merged.
+        if (deduplicateDataDictionaryByType) {
+            java.util.Set<String> seenTypes = new java.util.HashSet<>();
+            List<XsdExtendedElement> deduped = filtered.stream()
+                    .filter(element -> {
+                        String type = element.getElementType();
+                        if (type == null || type.isBlank()
+                                || type.startsWith("xs:") || type.startsWith("xsd:")) {
+                            return true;
+                        }
+                        return seenTypes.add(xsdDocService.stripNamespace(type));
+                    })
+                    .toList();
+            logger.info("Data dictionary deduplicated by type: {} -> {} rows", filtered.size(), deduped.size());
+            filtered = deduped;
+        }
+        final List<XsdExtendedElement> allElements = filtered;
 
         // Kick off the Excel export on a background thread so it runs in parallel with the (much
         // faster) HTML rendering instead of blocking it. It is awaited later via

--- a/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
+++ b/src/main/java/org/fxt/freexmltoolkit/service/XsdDocumentationService.java
@@ -140,6 +140,7 @@ public class XsdDocumentationService {
     private boolean generateSvgOverviewPage = true; // Whether to generate the schema-svg.html overview page
     private boolean addMetadataInOutput = false; // Whether to add metadata comments to generated HTML files
     private String faviconPath = null; // Optional path to custom favicon for HTML documentation
+    private boolean deduplicateDataDictionaryByType = false; // List each named type only once in the data dictionary
 
     // Per-run memo of XPath-independent identity-constraint results, keyed by the source DOM node.
     // Repeated expansions of a shared type reuse the cached result instead of re-parsing constraints.
@@ -247,6 +248,17 @@ public class XsdDocumentationService {
     }
 
     /**
+     * Sets whether the data dictionary lists each named complex/simple type only once (the first
+     * occurrence) instead of every recursive occurrence. Elements with a built-in or no type are
+     * always listed individually.
+     *
+     * @param deduplicateDataDictionaryByType {@code true} to collapse repeated named types
+     */
+    public void setDeduplicateDataDictionaryByType(boolean deduplicateDataDictionaryByType) {
+        this.deduplicateDataDictionaryByType = deduplicateDataDictionaryByType;
+    }
+
+    /**
      * Returns the configured favicon path.
      *
      * @return Path to the favicon file, or null if not set
@@ -337,6 +349,7 @@ public class XsdDocumentationService {
         xsdDocumentationHtmlService.setIncludedLanguages(this.includedLanguages);
         xsdDocumentationHtmlService.setAddMetadataInOutput(this.addMetadataInOutput);
         xsdDocumentationHtmlService.setFaviconPath(this.faviconPath);
+        xsdDocumentationHtmlService.setDeduplicateDataDictionaryByType(this.deduplicateDataDictionaryByType);
 
         xsdDocumentationSvgService.setOutputDirectory(outputDirectory);
         xsdDocumentationSvgService.setDocumentationData(xsdDocumentationData);

--- a/src/main/resources/xsdDocumentation/dataDictionary.html
+++ b/src/main/resources/xsdDocumentation/dataDictionary.html
@@ -167,31 +167,40 @@
     </div>
 </main>
 
-<!-- Scroll-to-Top Button and its script -->
+<!-- Scroll-to-Top Button (self-contained styling so it works regardless of the purged utility CSS) -->
 <button id="scrollToTopBtn" aria-label="Scroll to top" title="Scroll to top"
-        class="hidden fixed bottom-8 right-8 bg-sky-600 hover:bg-sky-700 text-white p-3 rounded-full shadow-lg transition-opacity duration-300">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-up-short"
-         viewBox="0 0 16 16">
+        style="position: fixed; bottom: 2rem; right: 2rem; z-index: 50; display: none;
+               align-items: center; justify-content: center; width: 3rem; height: 3rem;
+               border: none; border-radius: 9999px; background-color: #0284c7; color: #ffffff;
+               box-shadow: 0 10px 15px -3px rgba(0,0,0,0.2); cursor: pointer;
+               transition: background-color 0.2s ease;"
+        onmouseover="this.style.backgroundColor='#0369a1'"
+        onmouseout="this.style.backgroundColor='#0284c7'">
+    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor"
+         class="bi bi-arrow-up-short" viewBox="0 0 16 16">
         <path fill-rule="evenodd"
               d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/>
     </svg>
 </button>
 
 <script>
-    // Logic for the Scroll-to-Top Button
-    const scrollToTopBtn = document.getElementById('scrollToTopBtn');
-
-    window.onscroll = function () {
-        if (document.body.scrollTop > 100 || document.documentElement.scrollTop > 100) {
-            scrollToTopBtn.classList.remove('hidden');
-        } else {
-            scrollToTopBtn.classList.add('hidden');
+    // Show the Scroll-to-Top button once the page is scrolled down; toggle via inline display
+    // (independent of any CSS framework utility classes).
+    (function () {
+        const scrollToTopBtn = document.getElementById('scrollToTopBtn');
+        if (!scrollToTopBtn) {
+            return;
         }
-    };
-
-    scrollToTopBtn.onclick = function () {
-        window.scrollTo({top: 0, behavior: 'smooth'});
-    };
+        const toggle = function () {
+            const scrolled = document.body.scrollTop > 100 || document.documentElement.scrollTop > 100;
+            scrollToTopBtn.style.display = scrolled ? 'flex' : 'none';
+        };
+        window.addEventListener('scroll', toggle, {passive: true});
+        toggle();
+        scrollToTopBtn.addEventListener('click', function () {
+            window.scrollTo({top: 0, behavior: 'smooth'});
+        });
+    })();
 </script>
 
 <script src="assets/search.js" defer></script>

--- a/src/test/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationViewTest.java
+++ b/src/test/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationViewTest.java
@@ -59,7 +59,7 @@ class DocumentationViewTest {
 
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> {
             view.generate(new DocumentationView.DocOptions(xsd.toFile(), out.toFile(), "HTML",
-                    true, false, false, false, false, "SVG", Set.of(), null, false, null, null));
+                    true, false, false, false, false, false, "SVG", Set.of(), null, false, null, null));
             return null;
         });
         WaitForAsyncUtils.waitFor(60, TimeUnit.SECONDS,
@@ -123,7 +123,7 @@ class DocumentationViewTest {
 
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> {
             view.generate(new DocumentationView.DocOptions(xsd.toFile(), out.toFile(), "PDF",
-                    true, false, false, false, false, "SVG", Set.of(), null, false, null,
+                    true, false, false, false, false, false, "SVG", Set.of(), null, false, null,
                     new DocumentationView.FormatOptions("Letter", true, false, true, true,
                             false, false, "Professional", "Draft", true, true)));
             return null;
@@ -186,7 +186,7 @@ class DocumentationViewTest {
         Files.writeString(xsd, XSD);
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> {
             view.generate(new DocumentationView.DocOptions(xsd.toFile(), null, "HTML",
-                    true, false, false, false, false, "SVG", Set.of(), null, false, null, null));
+                    true, false, false, false, false, false, "SVG", Set.of(), null, false, null, null));
             return null;
         });
         WaitForAsyncUtils.waitForFxEvents();


### PR DESCRIPTION
…-top

- Add an optional "Deduplicate data dictionary by type" toggle (HTML options, default off). When enabled, the data dictionary lists each named complex/simple type only once (first occurrence by counter); elements with a built-in (xs:*) or no type stay individual so leaf fields are not merged. Applies to both the HTML page and the Excel export. Plumbed UI -> DocOptions -> XsdDocumentationService -> XsdDocumentationHtmlService.generateDataDictionaryPage.
- Fix the data dictionary "scroll to top" button: it depended on Tailwind utility classes and was effectively invisible; made it self-contained with inline styles and a display toggle so it works regardless of the purged utility CSS.