### PR TITLE
polish(xsd-doc): rebalance Generate Documentation layout

### DIFF
--- a/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
+++ b/src/main/java/org/fxt/freexmltoolkit/controls/shell/editor/DocumentationView.java
@@ -303,23 +303,31 @@ public class DocumentationView extends BorderPane {
                 formatOptionsBox,
                 sectionLabel("LANGUAGES"), languagesBox,
                 openAfter, runRow, status);
-        form.setPrefWidth(430);
-        form.setMinWidth(380);
+        form.getStyleClass().add("fxt-docgen-form");
+        // The form is the primary, comfortably-sized area: it grows but is capped
+        // so it never stretches absurdly wide on large displays.
+        form.setMaxWidth(640);
         ScrollPane formScroll = new ScrollPane(form);
         formScroll.setFitToWidth(true);
         formScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         formScroll.getStyleClass().add("edge-to-edge");
 
+        // PROGRESS is a bounded-width secondary panel on the right.
         Region progressHeaderSpacer = new Region();
         HBox.setHgrow(progressHeaderSpacer, Priority.ALWAYS);
         HBox progressHeader = new HBox(8, sectionLabel("PROGRESS"), progressHeaderSpacer, spinner, elapsedLabel);
         progressHeader.setAlignment(Pos.CENTER_LEFT);
         VBox progressBox = new VBox(8, progressHeader, progressList);
-        progressBox.setPadding(new Insets(0, 0, 0, 20));
+        progressBox.getStyleClass().add("fxt-docgen-progress-pane");
+        progressBox.setPrefWidth(300);
+        progressBox.setMinWidth(240);
+        progressBox.setMaxWidth(340);
 
-        BorderPane card = new BorderPane(progressBox);
+        HBox body = new HBox(20, formScroll, progressBox);
+        HBox.setHgrow(formScroll, Priority.ALWAYS);
+
+        BorderPane card = new BorderPane(body);
         card.setTop(new VBox(16, header, new Region()));
-        card.setLeft(formScroll);
         card.getStyleClass().add("fxt-favmgr-card");
 
         setCenter(card);

--- a/src/main/resources/css/unified-shell.css
+++ b/src/main/resources/css/unified-shell.css
@@ -1760,6 +1760,22 @@
     -fx-background-color: -fxt-bg-canvas;
 }
 
+/* The settings form: comfortable horizontal breathing room so sections
+   (SOURCE & OUTPUT, etc.) never sit flush against the card edge. The trailing
+   right padding keeps content clear of the (NEVER-shown but space-reserving)
+   scrollbar gutter and the PROGRESS divider. */
+.fxt-docgen-form {
+    -fx-padding: 2 20 8 8;
+}
+
+/* PROGRESS: a bounded secondary panel, visually set off from the form by a
+   subtle divider rather than competing for primary space. */
+.fxt-docgen-progress-pane {
+    -fx-padding: 0 0 0 20;
+    -fx-border-color: transparent transparent transparent -fxt-border;
+    -fx-border-width: 0 0 0 1;
+}
+
 .fxt-docgen-progress {
     -fx-background-color: -fxt-bg-surface-2;
     -fx-background-radius: 8;


### PR DESCRIPTION
The settings form was pinned to a fixed ~430px left column while the PROGRESS panel consumed all remaining width, so the settings felt cramped and progress dominated; the form also had no horizontal breathing room.

- Lay the form and PROGRESS side by side in a single HBox: the form is now the primary, growing area (capped at 640px so it doesn't stretch absurdly wide) and PROGRESS is a bounded-width secondary panel (240-340px) on the right with a subtle left divider.
- Add comfortable horizontal padding to the form (fxt-docgen-form) so the SOURCE & OUTPUT / FORMAT / OPTIONS sections have side margins.

Layout/CSS only - all node ids and public methods are unchanged.